### PR TITLE
Removed reflection dependency from GeneralAppModel

### DIFF
--- a/ReflectionAppModel/ReflectionDescriptorMaker.cs
+++ b/ReflectionAppModel/ReflectionDescriptorMaker.cs
@@ -16,7 +16,7 @@ namespace System.CommandLine.ReflectionAppModel
                                      object dataSource,
                                      object parentDataSource = null,
                                      Type[] ommittedTypes = null)
-            : base(strategy, dataSource, parentDataSource)
+            : base(strategy, new ReflectionSpecificSource(), dataSource, parentDataSource)
         {
             OmmittedTypes = ommittedTypes ?? commonOmmittedTypes;
         }
@@ -48,81 +48,81 @@ namespace System.CommandLine.ReflectionAppModel
 
         protected Type[] OmmittedTypes { get; }
 
-        protected override IEnumerable<Candidate> GetChildCandidates(SymbolDescriptorBase commandDescriptor)
-        {
-            var item = commandDescriptor.Raw;
-            return item switch
-            {
-                MethodInfo m => m.GetParameters().Select(p => GetCandidateInternal(p)),
-                Type t => GetTypeChildren(Strategy, commandDescriptor, t, c => GetCandidate(c.Item)),
-                _ => new List<Candidate>(),
+        //protected override IEnumerable<Candidate> GetChildCandidates(SymbolDescriptorBase commandDescriptor)
+        //{
+        //    var item = commandDescriptor.Raw;
+        //    return item switch
+        //    {
+        //        MethodInfo m => m.GetParameters().Select(p => GetCandidateInternal(p)),
+        //        Type t => GetTypeChildren(Strategy, commandDescriptor, t, c => GetCandidate(c.Item)),
+        //        _ => new List<Candidate>(),
 
-            };
+        //    };
 
-            static IEnumerable<Candidate> GetTypeChildren(Strategy strategy, SymbolDescriptorBase commandDescriptor, Type t, Func<Candidate, Candidate> fillCandidate)
-            {
-                var derivedTypes = strategy.GetCandidateRules.GetCandidates(commandDescriptor).Select(c=> fillCandidate(c));
-                return derivedTypes.Union(t.GetProperties().Select(p => GetCandidateInternal(p)));
-            }
-        }
+        //    static IEnumerable<Candidate> GetTypeChildren(Strategy strategy, SymbolDescriptorBase commandDescriptor, Type t, Func<Candidate, Candidate> fillCandidate)
+        //    {
+        //        var derivedTypes = strategy.GetCandidateRules.GetCandidates(commandDescriptor).Select(c => fillCandidate(c));
+        //        return derivedTypes.Union(t.GetProperties().Select(p => GetCandidateInternal(p)));
+        //    }
+        //}
 
 
-        protected override Type GetArgumentType(Candidate candidate)
-            => candidate.Item switch
-            {
-                PropertyInfo prop => prop.PropertyType,
-                ParameterInfo param => param.ParameterType,
-                _ => null
-            };
+        //protected override Type GetArgumentType(Candidate candidate)
+        //    => candidate.Item switch
+        //    {
+        //        PropertyInfo prop => prop.PropertyType,
+        //        ParameterInfo param => param.ParameterType,
+        //        _ => null
+        //    };
 
-        protected override Candidate GetCandidate(object item)
-           => item switch
-           {
-               Type typeItem => GetCandidateInternal(typeItem),
-               MethodInfo methodItem => GetCandidateInternal(methodItem),
-               ParameterInfo parameterInfo => GetCandidateInternal(parameterInfo),
-               PropertyInfo propertyInfo => GetCandidateInternal(propertyInfo),
-               _ => null
-           };
+        //protected override Candidate GetCandidate(object item)
+        //   => item switch
+        //   {
+        //       Type typeItem => GetCandidateInternal(typeItem),
+        //       MethodInfo methodItem => GetCandidateInternal(methodItem),
+        //       ParameterInfo parameterInfo => GetCandidateInternal(parameterInfo),
+        //       PropertyInfo propertyInfo => GetCandidateInternal(propertyInfo),
+        //       _ => null
+        //   };
 
-        private static Candidate GetCandidateInternal(PropertyInfo propertyInfo)
-        {
-            var name = propertyInfo.Name;
-            var candidate = new Candidate(propertyInfo, propertyInfo.Name);
-            candidate.AddTraitRange(propertyInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
-            candidate.AddTrait(name);
-            candidate.AddTrait(new IdentityWrapper<string>(name));
-            return candidate;
-        }
+        //private static Candidate GetCandidateInternal(PropertyInfo propertyInfo)
+        //{
+        //    var name = propertyInfo.Name;
+        //    var candidate = new Candidate(propertyInfo, propertyInfo.Name);
+        //    candidate.AddTraitRange(propertyInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+        //    candidate.AddTrait(name);
+        //    candidate.AddTrait(new IdentityWrapper<string>(name));
+        //    return candidate;
+        //}
 
-        private static Candidate GetCandidateInternal(ParameterInfo parameterInfo)
-        {
-            var name = parameterInfo.Name;
-            var candidate = new Candidate(parameterInfo, parameterInfo.Name );
-            candidate.AddTraitRange(parameterInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
-            candidate.AddTrait(name);
-            candidate.AddTrait(new IdentityWrapper<string>(name));
-            return candidate;
-        }
+        //private static Candidate GetCandidateInternal(ParameterInfo parameterInfo)
+        //{
+        //    var name = parameterInfo.Name;
+        //    var candidate = new Candidate(parameterInfo, parameterInfo.Name);
+        //    candidate.AddTraitRange(parameterInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+        //    candidate.AddTrait(name);
+        //    candidate.AddTrait(new IdentityWrapper<string>(name));
+        //    return candidate;
+        //}
 
-        private static Candidate GetCandidateInternal(MethodInfo methodInfo)
-        {
-            var name = methodInfo.Name;
-            var candidate = new Candidate(methodInfo, methodInfo.Name);
-            candidate.AddTraitRange(methodInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
-            candidate.AddTrait(name);
-            candidate.AddTrait(new IdentityWrapper<string>(name));
-            return candidate;
-        }
+        //private static Candidate GetCandidateInternal(MethodInfo methodInfo)
+        //{
+        //    var name = methodInfo.Name;
+        //    var candidate = new Candidate(methodInfo, methodInfo.Name);
+        //    candidate.AddTraitRange(methodInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+        //    candidate.AddTrait(name);
+        //    candidate.AddTrait(new IdentityWrapper<string>(name));
+        //    return candidate;
+        //}
 
-        private static Candidate GetCandidateInternal(Type type)
-        {
-            var name = type.Name;
-            var candidate = new Candidate(type, type.Name);
-            candidate.AddTraitRange(type.GetCustomAttributes(Context.IncludeBaseClassAttributes));
-            candidate.AddTrait(name);
-            candidate.AddTrait(new IdentityWrapper<string>(name));
-            return candidate;
-        }
+        //private static Candidate GetCandidateInternal(Type type)
+        //{
+        //    var name = type.Name;
+        //    var candidate = new Candidate(type, type.Name);
+        //    candidate.AddTraitRange(type.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+        //    candidate.AddTrait(name);
+        //    candidate.AddTrait(new IdentityWrapper<string>(name));
+        //    return candidate;
+        //}
     }
 }

--- a/ReflectionAppModel/ReflectionSpecificSource.cs
+++ b/ReflectionAppModel/ReflectionSpecificSource.cs
@@ -47,11 +47,6 @@ namespace System.CommandLine.ReflectionAppModel
                _ => null
            };
 
-        //public override IEnumerable<T> GetMachingAttributes<T>(SymbolDescriptorBase symbolDescriptor, IEnumerable<T> items, SymbolDescriptorBase parentSymbolDescriptor)
-        //{
-        //    throw new NotImplementedException();
-        //}
-
         public override bool ComplexAttributeHasAtLeastOneProperty(IEnumerable<ComplexAttributeRule.NameAndType> propertyNamesAndTypes, object attribute)
         {
 

--- a/ReflectionAppModel/ReflectionSpecificSource.cs
+++ b/ReflectionAppModel/ReflectionSpecificSource.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.GeneralAppModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace System.CommandLine.ReflectionAppModel
+{
+    public class ReflectionSpecificSource : SpecificSource
+    {
+        public override IEnumerable<Candidate> GetChildCandidates(Strategy strategy, SymbolDescriptorBase commandDescriptor)
+        {
+            var item = commandDescriptor.Raw;
+            return item switch
+            {
+                MethodInfo m => m.GetParameters().Select(p => GetCandidateInternal(p)),
+                Type t => GetTypeChildren(strategy, commandDescriptor, t, c => GetCandidate(c.Item)),
+                _ => new List<Candidate>(),
+
+            };
+
+            static IEnumerable<Candidate> GetTypeChildren(Strategy strategy, SymbolDescriptorBase commandDescriptor, Type t, Func<Candidate, Candidate> fillCandidate)
+            {
+                var derivedTypes = strategy.GetCandidateRules.GetCandidates(commandDescriptor).Select(c => fillCandidate(c));
+                return derivedTypes.Union(t.GetProperties().Select(p => GetCandidateInternal(p)));
+            }
+        }
+
+
+        public override Type GetArgumentType(Candidate candidate)
+            => candidate.Item switch
+            {
+                PropertyInfo prop => prop.PropertyType,
+                ParameterInfo param => param.ParameterType,
+                _ => null
+            };
+
+        public override Candidate GetCandidate(object item)
+           => item switch
+           {
+               Type typeItem => GetCandidateInternal(typeItem),
+               MethodInfo methodItem => GetCandidateInternal(methodItem),
+               ParameterInfo parameterInfo => GetCandidateInternal(parameterInfo),
+               PropertyInfo propertyInfo => GetCandidateInternal(propertyInfo),
+               _ => null
+           };
+
+        private static Candidate GetCandidateInternal(PropertyInfo propertyInfo)
+        {
+            var name = propertyInfo.Name;
+            var candidate = new Candidate(propertyInfo, propertyInfo.Name);
+            candidate.AddTraitRange(propertyInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+            candidate.AddTrait(name);
+            candidate.AddTrait(new IdentityWrapper<string>(name));
+            return candidate;
+        }
+
+        private static Candidate GetCandidateInternal(ParameterInfo parameterInfo)
+        {
+            var name = parameterInfo.Name;
+            var candidate = new Candidate(parameterInfo, parameterInfo.Name);
+            candidate.AddTraitRange(parameterInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+            candidate.AddTrait(name);
+            candidate.AddTrait(new IdentityWrapper<string>(name));
+            return candidate;
+        }
+
+        private static Candidate GetCandidateInternal(MethodInfo methodInfo)
+        {
+            var name = methodInfo.Name;
+            var candidate = new Candidate(methodInfo, methodInfo.Name);
+            candidate.AddTraitRange(methodInfo.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+            candidate.AddTrait(name);
+            candidate.AddTrait(new IdentityWrapper<string>(name));
+            return candidate;
+        }
+
+        private static Candidate GetCandidateInternal(Type type)
+        {
+            var name = type.Name;
+            var candidate = new Candidate(type, type.Name);
+            candidate.AddTraitRange(type.GetCustomAttributes(Context.IncludeBaseClassAttributes));
+            candidate.AddTrait(name);
+            candidate.AddTrait(new IdentityWrapper<string>(name));
+            return candidate;
+        }
+    }
+}

--- a/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
+++ b/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
@@ -33,10 +33,6 @@ namespace System.CommandLine.GeneralAppModel
             ParentDataSource = parentDataSource;
         }
 
-        //protected abstract Candidate GetCandidate(object item);
-        //protected abstract Type GetArgumentType(Candidate candidate);
-        //protected abstract IEnumerable<Candidate> GetChildCandidates(SymbolDescriptorBase commandDescriptor);
-
         protected Strategy Strategy { get; }
         protected object DataSource { get; }
         protected object ParentDataSource { get; }

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeRuleBase.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeRuleBase.cs
@@ -19,24 +19,25 @@ namespace System.CommandLine.GeneralAppModel.Rules
                                              IEnumerable<T> items,
                                              SymbolDescriptorBase parentSymbolDescriptor)
            => items
-                   .Where(item => IsMatch(symbolDescriptor, item, parentSymbolDescriptor));
-  
-        protected bool IsMatch(SymbolDescriptorBase symbolDescriptor,
-                      object item,
-                      SymbolDescriptorBase parentSymbolDescriptor)
-        {
-            return item switch
-            {
-                Attribute a => DoesAttributeMatch(AttributeName, a),
-                _ => false
-            };
-        }
+                   .Where(item => SpecificSource.Tools.IsAttributeAMatch(AttributeName, symbolDescriptor, item,
+                                                                         parentSymbolDescriptor));
 
-        protected bool DoesAttributeMatch(string attributeName, Attribute a)
-        {
-            var itemName = a.GetType().Name;
-            return itemName.Equals(attributeName, StringComparison.OrdinalIgnoreCase)
-                || itemName.Equals(attributeName + "Attribute", StringComparison.OrdinalIgnoreCase);
-        }
+        //protected bool IsMatch(SymbolDescriptorBase symbolDescriptor,
+        //              object item,
+        //              SymbolDescriptorBase parentSymbolDescriptor)
+        //{
+        //    return item switch
+        //    {
+        //        Attribute a => DoesAttributeMatch(AttributeName, a),
+        //        _ => false
+        //    };
+        //}
+
+        //protected bool DoesAttributeMatch(string attributeName, Attribute a)
+        //{
+        //    var itemName = a.GetType().Name;
+        //    return itemName.Equals(attributeName, StringComparison.OrdinalIgnoreCase)
+        //        || itemName.Equals(attributeName + "Attribute", StringComparison.OrdinalIgnoreCase);
+        //}
     }
 }

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeRuleBase.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeRuleBase.cs
@@ -21,23 +21,5 @@ namespace System.CommandLine.GeneralAppModel.Rules
            => items
                    .Where(item => SpecificSource.Tools.IsAttributeAMatch(AttributeName, symbolDescriptor, item,
                                                                          parentSymbolDescriptor));
-
-        //protected bool IsMatch(SymbolDescriptorBase symbolDescriptor,
-        //              object item,
-        //              SymbolDescriptorBase parentSymbolDescriptor)
-        //{
-        //    return item switch
-        //    {
-        //        Attribute a => DoesAttributeMatch(AttributeName, a),
-        //        _ => false
-        //    };
-        //}
-
-        //protected bool DoesAttributeMatch(string attributeName, Attribute a)
-        //{
-        //    var itemName = a.GetType().Name;
-        //    return itemName.Equals(attributeName, StringComparison.OrdinalIgnoreCase)
-        //        || itemName.Equals(attributeName + "Attribute", StringComparison.OrdinalIgnoreCase);
-        //}
     }
 }

--- a/System.CommandLine.GeneralAppModel/Rules/ComplexAttributeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/ComplexAttributeRule.cs
@@ -21,10 +21,10 @@ namespace System.CommandLine.GeneralAppModel
         public new(bool success, Dictionary<string, object> value) GetFirstOrDefaultValue(
                   SymbolDescriptorBase symbolDescriptor, IEnumerable<object> items, SymbolDescriptorBase parentSymbolDescriptor)
         {
+            SpecificSource tools = SpecificSource.Tools;
             var attributes = GetMatches(symbolDescriptor, items, parentSymbolDescriptor)
-                                .OfType<Attribute>()
                                 .ToList();
-            if (attributes.Any(a => HasAtLeastOneProperty(a)))
+            if (attributes.Any(a => tools.ComplexAttributeHasAtLeastOneProperty(PropertyNamesAndTypes, a)))
             {
                 var dictionary = new Dictionary<string, object>();
                 foreach (var attribute in attributes)
@@ -43,12 +43,6 @@ namespace System.CommandLine.GeneralAppModel
                 return (true, dictionary);
             }
             return (false, default);
-        }
-
-        private bool HasAtLeastOneProperty(Attribute attribute)
-        {
-            var propertyNames = PropertyNamesAndTypes.Select(p => p.PropertyName);
-            return attribute.GetType().GetProperties().Any(p => propertyNames.Contains(p.Name));
         }
 
         public override string RuleDescription<TIRuleSet>()

--- a/System.CommandLine.GeneralAppModel/Rules/IRuleAliases.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/IRuleAliases.cs
@@ -1,11 +1,6 @@
 ﻿namespace System.CommandLine.GeneralAppModel
 {
     public interface IRuleAliases : IRule
-    {
-        // TODO: 
-        //(uint MinimumCount, uint MaximumCount) GetArity(SymbolDescriptorBase symbolDescriptor,
-        //                                                IEnumerable<object> item,
-        //                                                SymbolDescriptorBase parentSymbolDescriptor);
-    }
+    { }
 
 }

--- a/System.CommandLine.GeneralAppModel/Rules/NamedAttributeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/NamedAttributeRule.cs
@@ -15,12 +15,11 @@ namespace System.CommandLine.GeneralAppModel
             : base(attributeName, symbolType)
         { }
 
-        public (bool success, bool value) GetFirstOrDefaultValue(SymbolDescriptorBase symbolDescriptor,
+        public virtual (bool success, bool value) GetFirstOrDefaultValue(SymbolDescriptorBase symbolDescriptor,
                                                                  IEnumerable<object> items,
                                                                  SymbolDescriptorBase parentSymbolDescriptor)
         {
-            var attributes = GetMatches(symbolDescriptor, items, parentSymbolDescriptor)
-                                .OfType<Attribute>();
+            var attributes = GetMatches(symbolDescriptor, items, parentSymbolDescriptor);
 
             return attributes.Any()
                     ? (true, true)

--- a/System.CommandLine.GeneralAppModel/Rules/NamedAttributeWithPropertyRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/NamedAttributeWithPropertyRule.cs
@@ -18,19 +18,6 @@ namespace System.CommandLine.GeneralAppModel
 
         public string PropertyName { get; }
         public Type Type { get; }
-
-        //private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
-        //{
-        //    return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
-        //        ? Array.Empty<Attribute>()
-        //        : items
-        //            .Where(a => SpecificSource.Tools.DoesAttributeMatch(AttributeName, a));
-        //}
-
-        //private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
-        //    => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
-        //                                .OfType<Attribute>();
-
     }
 
     public class NamedAttributeWithPropertyRule<TValue> : NamedAttributeWithPropertyRule, IRuleGetValue<TValue>, IRuleGetValues<TValue>
@@ -56,51 +43,6 @@ namespace System.CommandLine.GeneralAppModel
             var attributes = GetMatches(symbolDescriptor, item, parentSymbolDescriptor);
             return attributes.SelectMany(a => SpecificSource.Tools. GetAttributeProperties<TValue>(a, PropertyName));
         }
-
-        //private static T GetProperty<T>(Attribute attribute, string propertyName)
-        //{
-        //    var raw = attribute.GetType()
-        //                      .GetProperty(propertyName)
-        //                      .GetValue(attribute);
-        //    return Conversions.To<T>(raw);
-        //}
-
-        //private static IEnumerable<T> GetProperties<T>(Attribute attribute, string propertyName)
-        //{
-        //    var property = attribute.GetType()
-        //                      .GetProperty(propertyName);
-        //    var raw = property.GetValue(attribute);
-        //    if (typeof(T).IsAssignableFrom(property.PropertyType))
-        //    {
-        //        return new T[] { Conversions.To<T>(raw) };
-        //    }
-        //    if (typeof(IEnumerable<T>).IsAssignableFrom(property.PropertyType) && raw is IEnumerable<T> x)
-        //    {
-        //        return x.Select(xx => Conversions.To<T>(xx));
-        //    }
-        //    if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && raw is IEnumerable y)
-        //    {
-        //        var list = new List<T>();
-        //        foreach (var item in y)
-        //        {
-        //            list.Add(Conversions.To<T>(item));
-        //        }
-        //        return list;
-        //    }
-        //    throw new InvalidOperationException("Unhandled Attribute PropertyType");
-        //}
-
-        //private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
-        //{
-        //    return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
-        //        ? Array.Empty<Attribute>()
-        //        : items
-        //            .Where(a => SpecificSource.Tools.DoesAttributeMatch(AttributeName, a));
-        //}
-
-        //private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
-        //    => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
-        //                                .OfType<Attribute>();
 
         public override string RuleDescription<TIRuleSet>()
             => $"If there is an attribute named '{AttributeName}', its '{PropertyName}' property, with type {typeof(TValue)}";

--- a/System.CommandLine.GeneralAppModel/Rules/NamedAttributeWithPropertyRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/NamedAttributeWithPropertyRule.cs
@@ -19,17 +19,17 @@ namespace System.CommandLine.GeneralAppModel
         public string PropertyName { get; }
         public Type Type { get; }
 
-        private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
-        {
-            return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
-                ? Array.Empty<Attribute>()
-                : items
-                    .Where(a => DoesAttributeMatch(AttributeName, a));
-        }
+        //private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
+        //{
+        //    return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
+        //        ? Array.Empty<Attribute>()
+        //        : items
+        //            .Where(a => SpecificSource.Tools.DoesAttributeMatch(AttributeName, a));
+        //}
 
-        private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
-            => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
-                                        .OfType<Attribute>();
+        //private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
+        //    => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
+        //                                .OfType<Attribute>();
 
     }
 
@@ -43,66 +43,64 @@ namespace System.CommandLine.GeneralAppModel
                                                                    IEnumerable<object> item,
                                                                    SymbolDescriptorBase parentSymbolDescriptor)
         {
-            var attributes = GetMatches(symbolDescriptor, item, parentSymbolDescriptor)
-                                .OfType<Attribute>();
+            var attributes = GetMatches(symbolDescriptor, item, parentSymbolDescriptor);
             if (attributes.Any())
             {
-                return (true, GetProperty<TValue>(attributes.FirstOrDefault(), PropertyName));
+                return (true, SpecificSource.Tools.GetAttributeProperty<TValue>(attributes.FirstOrDefault(), PropertyName));
             }
             return (false, default);
         }
 
         public IEnumerable<TValue> GetAllValues(SymbolDescriptorBase symbolDescriptor, IEnumerable<object> item, SymbolDescriptorBase parentSymbolDescriptor)
         {
-            var attributes = GetMatches(symbolDescriptor, item, parentSymbolDescriptor)
-                                .OfType<Attribute>();
-            return attributes.SelectMany(a => GetProperties<TValue>(a, PropertyName));
+            var attributes = GetMatches(symbolDescriptor, item, parentSymbolDescriptor);
+            return attributes.SelectMany(a => SpecificSource.Tools. GetAttributeProperties<TValue>(a, PropertyName));
         }
 
-        private static T GetProperty<T>(Attribute attribute, string propertyName)
-        {
-            var raw = attribute.GetType()
-                              .GetProperty(propertyName)
-                              .GetValue(attribute);
-            return Conversions.To<T>(raw);
-        }
+        //private static T GetProperty<T>(Attribute attribute, string propertyName)
+        //{
+        //    var raw = attribute.GetType()
+        //                      .GetProperty(propertyName)
+        //                      .GetValue(attribute);
+        //    return Conversions.To<T>(raw);
+        //}
 
-        private static IEnumerable<T> GetProperties<T>(Attribute attribute, string propertyName)
-        {
-            var property = attribute.GetType()
-                              .GetProperty(propertyName);
-            var raw = property.GetValue(attribute);
-            if (typeof(T).IsAssignableFrom(property.PropertyType))
-            {
-                return new T[] { Conversions.To<T>(raw) };
-            }
-            if (typeof(IEnumerable<T>).IsAssignableFrom(property.PropertyType) && raw is IEnumerable<T> x)
-            {
-                return x.Select(xx => Conversions.To<T>(xx));
-            }
-            if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && raw is IEnumerable y)
-            {
-                var list = new List<T>();
-                foreach (var item in y)
-                {
-                    list.Add(Conversions.To<T>(item));
-                }
-                return list;
-            }
-            throw new InvalidOperationException("Unhandled Attribute PropertyType");
-        }
+        //private static IEnumerable<T> GetProperties<T>(Attribute attribute, string propertyName)
+        //{
+        //    var property = attribute.GetType()
+        //                      .GetProperty(propertyName);
+        //    var raw = property.GetValue(attribute);
+        //    if (typeof(T).IsAssignableFrom(property.PropertyType))
+        //    {
+        //        return new T[] { Conversions.To<T>(raw) };
+        //    }
+        //    if (typeof(IEnumerable<T>).IsAssignableFrom(property.PropertyType) && raw is IEnumerable<T> x)
+        //    {
+        //        return x.Select(xx => Conversions.To<T>(xx));
+        //    }
+        //    if (typeof(IEnumerable).IsAssignableFrom(property.PropertyType) && raw is IEnumerable y)
+        //    {
+        //        var list = new List<T>();
+        //        foreach (var item in y)
+        //        {
+        //            list.Add(Conversions.To<T>(item));
+        //        }
+        //        return list;
+        //    }
+        //    throw new InvalidOperationException("Unhandled Attribute PropertyType");
+        //}
 
-        private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
-        {
-            return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
-                ? Array.Empty<Attribute>()
-                : items
-                    .Where(a => DoesAttributeMatch(AttributeName, a));
-        }
+        //private IEnumerable<Attribute> GetMatchingAttributes(SymbolDescriptorBase symbolDescriptor, IEnumerable<Attribute> items)
+        //{
+        //    return SymbolType != SymbolType.All && SymbolType != symbolDescriptor.SymbolType
+        //        ? Array.Empty<Attribute>()
+        //        : items
+        //            .Where(a => SpecificSource.Tools.DoesAttributeMatch(AttributeName, a));
+        //}
 
-        private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
-            => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
-                                        .OfType<Attribute>();
+        //private IEnumerable<Attribute> GetAttributes(ICustomAttributeProvider attributeProvider)
+        //    => attributeProvider.GetCustomAttributes(Context.IncludeBaseClassAttributes)
+        //                                .OfType<Attribute>();
 
         public override string RuleDescription<TIRuleSet>()
             => $"If there is an attribute named '{AttributeName}', its '{PropertyName}' property, with type {typeof(TValue)}";

--- a/System.CommandLine.GeneralAppModel/SpecificSource.cs
+++ b/System.CommandLine.GeneralAppModel/SpecificSource.cs
@@ -1,15 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace System.CommandLine.GeneralAppModel
 {
+    /// <summary>
+    /// This is the base class for source specific code - such as reflection of Roslyn specific code. 
+    /// GeneralAppModel should have no (zero, nada) dependencies on any specific type of source.
+    /// </summary>
     public abstract class SpecificSource
     {
         public static SpecificSource Tools { get; internal set; }
 
         public abstract Candidate GetCandidate( object item);
         public abstract Type GetArgumentType(Candidate candidate);
-        public abstract IEnumerable<Candidate> GetChildCandidates(Strategy strategy, SymbolDescriptorBase commandDescriptor);
+        public abstract IEnumerable<Candidate> GetChildCandidates(Strategy strategy,
+                                                                  SymbolDescriptorBase commandDescriptor);
+
+        //public abstract IEnumerable<T> GetMachingAttributes<T>(SymbolDescriptorBase symbolDescriptor,
+        //                                                       IEnumerable<T> items,
+        //                                                       SymbolDescriptorBase parentSymbolDescriptor);
+        public abstract bool ComplexAttributeHasAtLeastOneProperty(IEnumerable<ComplexAttributeRule.NameAndType> propertyNamesAndTypes,
+                                                                   object attribute);
+        public abstract bool IsAttributeAMatch(string attributeName,
+                                               SymbolDescriptorBase symbolDescriptor,
+                                               object item,
+                                               SymbolDescriptorBase parentSymbolDescriptor);
+     
+        public abstract bool DoesAttributeMatch(string attributeName, object a);
+        public abstract  T GetAttributeProperty<T>(object attribute, string propertyName);
+        public abstract  IEnumerable<T> GetAttributeProperties<T>(object attribute, string propertyName);
     }
 }

--- a/System.CommandLine.GeneralAppModel/SpecificSource.cs
+++ b/System.CommandLine.GeneralAppModel/SpecificSource.cs
@@ -15,10 +15,7 @@ namespace System.CommandLine.GeneralAppModel
         public abstract IEnumerable<Candidate> GetChildCandidates(Strategy strategy,
                                                                   SymbolDescriptorBase commandDescriptor);
 
-        //public abstract IEnumerable<T> GetMachingAttributes<T>(SymbolDescriptorBase symbolDescriptor,
-        //                                                       IEnumerable<T> items,
-        //                                                       SymbolDescriptorBase parentSymbolDescriptor);
-        public abstract bool ComplexAttributeHasAtLeastOneProperty(IEnumerable<ComplexAttributeRule.NameAndType> propertyNamesAndTypes,
+         public abstract bool ComplexAttributeHasAtLeastOneProperty(IEnumerable<ComplexAttributeRule.NameAndType> propertyNamesAndTypes,
                                                                    object attribute);
         public abstract bool IsAttributeAMatch(string attributeName,
                                                SymbolDescriptorBase symbolDescriptor,

--- a/System.CommandLine.GeneralAppModel/SpecificSource.cs
+++ b/System.CommandLine.GeneralAppModel/SpecificSource.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public abstract class SpecificSource
+    {
+        public static SpecificSource Tools { get; internal set; }
+
+        public abstract Candidate GetCandidate( object item);
+        public abstract Type GetArgumentType(Candidate candidate);
+        public abstract IEnumerable<Candidate> GetChildCandidates(Strategy strategy, SymbolDescriptorBase commandDescriptor);
+    }
+}


### PR DESCRIPTION
Removed all occurrences of "Attribute" and "GetType()" (match case, single word).

Moved all Reflection code to ReflectionSpecificSource (out of the AttributeRules and DescriptorMakerBase). Open to other naming here. 