### PR TITLE
Implemented ArgumentTypeInfo

### DIFF
--- a/ReflectionAppModel/ReflectionSpecificSource.cs
+++ b/ReflectionAppModel/ReflectionSpecificSource.cs
@@ -29,13 +29,13 @@ namespace System.CommandLine.ReflectionAppModel
             }
         }
 
-        public override Type GetArgumentType(Candidate candidate)
+        public override ArgTypeInfo GetArgTypeInfo(Candidate candidate)
             => candidate.Item switch
             {
-                PropertyInfo prop => prop.PropertyType,
-                ParameterInfo param => param.ParameterType,
-                Type type => type,
-                _ => throw new InvalidOperationException("There must be an argument type")
+                PropertyInfo prop => new ArgTypeInfo( prop.PropertyType),
+                ParameterInfo param => new ArgTypeInfo(param.ParameterType),
+                Type type => new ArgTypeInfo(type),
+                _ => throw new InvalidOperationException("Argument result is of an unexpected type")
             };
 
         public override Candidate CreateCandidate(object item)

--- a/System.CommandLine.GeneralAppModel.Tests/Assertions/ArgumentDescriptorAssertions.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/Assertions/ArgumentDescriptorAssertions.cs
@@ -65,9 +65,10 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         public AndConstraint<ArgumentDescriptorAssertions> HaveArgumentType(Type expected)
         {
+            Type actual = Subject.ArgumentType.GetArgumentType<Type>();
             Execute.Assertion
-                 .ForCondition(Subject.ArgumentType == expected)
-                 .FailWith(Utils.DisplayEqualsFailure(SymbolType.Argument, "ArgumentType", expected, Subject.ArgumentType));
+                 .ForCondition(actual == expected)
+                 .FailWith(Utils.DisplayEqualsFailure(SymbolType.Argument, "ArgumentType", expected, actual));
 
             return new AndConstraint<ArgumentDescriptorAssertions>(this);
         }

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/ArgumentTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/ArgumentTestData.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions.Execution;
 using System.CommandLine.GeneralAppModel.Descriptors;
 using System.Linq;
+using Xunit.Sdk;
 
 namespace System.CommandLine.GeneralAppModel.Tests.Maker
 {
@@ -10,7 +11,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
             : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyRaw) { Name = DummyCommandName })
         {
             Descriptor.Arguments.Add(
-                new ArgumentDescriptor(argumentType, SymbolDescriptor.Empty, DummyRaw)
+                new ArgumentDescriptor(new ArgTypeInfo ( argumentType), SymbolDescriptor.Empty, DummyRaw)
                 {
                     Name = name,
                     Description = description,
@@ -48,7 +49,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         public ArgumentArityTestData(bool isSet, int? minValue = null, int? maxValue = null)
             : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyRaw) { Name = DummyCommandName })
         {
-            var argDescriptor = new ArgumentDescriptor(typeof(string), SymbolDescriptor.Empty, DummyRaw)
+            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo (  typeof(string)), SymbolDescriptor.Empty, DummyRaw)
             {
                 Name = DummyArgumentName,
             };
@@ -87,7 +88,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         public ArgumentDefaultValueTestData(bool isSet, object defaultValue)
             : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyRaw) { Name = DummyCommandName })
         {
-            var argDescriptor = new ArgumentDescriptor(typeof(string), SymbolDescriptor.Empty, DummyRaw)
+            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, DummyRaw)
             {
                 Name = DummyArgumentName,
             };

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
@@ -122,7 +122,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
               { Name = DummyCommandName })
         {
             Descriptor.Arguments.Add(
-                    new ArgumentDescriptor(typeof(string), SymbolDescriptor.Empty, Utils.EmptyRawForTest)
+                    new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, Utils.EmptyRawForTest)
                     {
                         Name = "HelloTo"
                     }

--- a/System.CommandLine.GeneralAppModel.Tests/TestSupport/TestDataExtensions.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/TestSupport/TestDataExtensions.cs
@@ -34,7 +34,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         public static ArgumentDescriptor CreateDescriptor(this ArgumentTestData data, ISymbolDescriptor parentSymbolDescriptor)
         {
             var _ = data.ArgumentType ?? throw new InvalidOperationException("ArgumentType cannot be null");
-            var arg = new ArgumentDescriptor(data.ArgumentType, parentSymbolDescriptor, data.Raw)
+            var arg = new ArgumentDescriptor(new ArgTypeInfo(data.ArgumentType), parentSymbolDescriptor, data.Raw)
             {
                 Name = data.Name,
                 Description = data.Description,

--- a/System.CommandLine.GeneralAppModel/ArgTypeInfo.cs
+++ b/System.CommandLine.GeneralAppModel/ArgTypeInfo.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    /// <summary>
+    /// Derived classes supply specific technology implementation for the 
+    /// ArgumentType. 
+    /// <br/>
+    /// For exmple: In Reflection, this provides a Type object. In Roslyn it provides
+    /// a syntax node that represents the type.
+    /// </summary>
+    public class ArgTypeInfo
+    {
+        public ArgTypeInfo(object typeRepresentation)
+        {
+            TypeRepresentation = typeRepresentation;
+        }
+
+        public object TypeRepresentation { get; }
+
+        public  T GetArgumentType<T>()
+            where T : class
+        {
+            if (TypeRepresentation is T t)
+            {
+                return t;
+            }
+            throw new NotImplementedException("Add other outputs like a Roslyn SyntaxNode");
+        }
+    }
+}

--- a/System.CommandLine.GeneralAppModel/CommandMaker.cs
+++ b/System.CommandLine.GeneralAppModel/CommandMaker.cs
@@ -86,7 +86,7 @@ namespace System.CommandLine.GeneralAppModel
         public static Argument MakeArgument(ArgumentDescriptor descriptor)
         {
             var arg = new Argument(descriptor.Name);
-            arg.ArgumentType = descriptor.ArgumentType;
+            arg.ArgumentType = descriptor.ArgumentType.GetArgumentType<Type>();
             AddAliases(arg, descriptor.Aliases);
             if (descriptor.Arity != null)
             {

--- a/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
+++ b/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
@@ -112,7 +112,7 @@ namespace System.CommandLine.GeneralAppModel
 
         private ArgumentDescriptor GetArgument(Candidate candidate, ISymbolDescriptor parentSymbolDescriptor)
         {
-            var argumentType = SpecificSource.Tools.GetArgumentType(candidate) ?? typeof(string);
+            var argumentType = SpecificSource.Tools.GetArgTypeInfo(candidate) ?? throw new InvalidOperationException("Type must be supplied for argument");
             var descriptor = new ArgumentDescriptor(argumentType, parentSymbolDescriptor, candidate.Item);
             var ruleSet = Strategy.ArgumentRules;
             FillSymbol(descriptor, ruleSet, candidate, parentSymbolDescriptor);

--- a/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
@@ -4,18 +4,18 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
 {
     public class ArgumentDescriptor : SymbolDescriptor
     {
-        public ArgumentDescriptor(Type argumentType, ISymbolDescriptor parentSymbolDescriptorBase,
+        public ArgumentDescriptor(ArgTypeInfo argumentTypeInfo, ISymbolDescriptor parentSymbolDescriptorBase,
                                    object? raw)
             : base(parentSymbolDescriptorBase, raw, SymbolType.Argument)
         {
-            ArgumentType = argumentType;
+            ArgumentType = argumentTypeInfo;
         }
 
         public ArityDescriptor? Arity { get; set; }
         //TODO: AllowedValues aren't supported in DescriptorMakerBase or tests
         public HashSet<string>? AllowedValues { get; } = new HashSet<string>();
         // TODO: Consider how ArgumentType works when coming from JSON. 
-        public Type ArgumentType { get; }
+        public ArgTypeInfo ArgumentType { get; }
         public DefaultValueDescriptor? DefaultValue { get; set; }
         public bool Required { get; set; }
 

--- a/System.CommandLine.GeneralAppModel/SpecificSource.cs
+++ b/System.CommandLine.GeneralAppModel/SpecificSource.cs
@@ -54,7 +54,7 @@ namespace System.CommandLine.GeneralAppModel
         /// for example we may have custom rules that require running code in the technology.
         /// </remarks>
         /// <returns></returns>
-        public abstract Type GetArgumentType(Candidate candidate);
+        public abstract ArgTypeInfo  GetArgTypeInfo(Candidate candidate);
 
         /// <summary>
         /// Given a command, return it's children - subcommands, options and arguments.


### PR DESCRIPTION
Fixed #56 

ArgumentType previously held as a Type, which is only valid for Reflection. 

Replaced with ArgumentTypeInfo. This introduces the possibility of different source and output argument type mechanisms (Reflection and SourceGen, for example). These conversions are *not* done. 

Also:

* No longer allows a string default for argument type
* Added validation for duplicate symbols in DescriptorValidator



