### PR TITLE
Description from Description source

### DIFF
--- a/ReflectionAppModel.Tests/CommandLineActivatorForTests.cs
+++ b/ReflectionAppModel.Tests/CommandLineActivatorForTests.cs
@@ -18,7 +18,7 @@ namespace System.CommandLine.ReflectionAppModel.Tests
                 this.commandDescriptor = commandDescriptor;
             }
 
-            protected override CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null)
+            public override CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null)
             {
                 return commandDescriptor;
             }

--- a/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
@@ -109,12 +109,12 @@ namespace System.CommandLine.GeneralAppModel.Tests
         }
 
         [Theory]
-        [InlineData(full, typeof(MethodWithOnlyOneParameter), "--" + constant.OptionName)]
-        [InlineData(full, typeof(MethodWithOneOptionByRemaining), "--" + constant.OptionName)]
-        [InlineData(full, typeof(MethodWithTwoOptionsByRemaining), "--" + constant.OptionName, "--" + constant.OptionName2)]
-        [InlineData(standard, typeof(MethodWithOnlyOneParameter), "--" + constant.OptionName)]
-        [InlineData(standard, typeof(MethodWithOneOptionByRemaining), "--" + constant.OptionName)]
-        [InlineData(standard, typeof(MethodWithTwoOptionsByRemaining), "--" + constant.OptionName, "--" + constant.OptionName2)]
+        [InlineData(full, typeof(MethodWithOnlyOneParameter), constant.OptionName)]
+        [InlineData(full, typeof(MethodWithOneOptionByRemaining), constant.OptionName)]
+        [InlineData(full, typeof(MethodWithTwoOptionsByRemaining), constant.OptionName, constant.OptionName2)]
+        [InlineData(standard, typeof(MethodWithOnlyOneParameter), constant.OptionName)]
+        [InlineData(standard, typeof(MethodWithOneOptionByRemaining), constant.OptionName)]
+        [InlineData(standard, typeof(MethodWithTwoOptionsByRemaining), constant.OptionName, constant.OptionName2)]
         public void CommandWithSubOptions(string useStrategy, Type typeToTest, params string[] argNames)
         {
             var method = typeToTest.GetMethods().First();
@@ -128,14 +128,14 @@ namespace System.CommandLine.GeneralAppModel.Tests
         #region Option tests
 
         [Theory]
-        [InlineData(full, typeof(ParameterOptionWithName), "--" + constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameAttribute), "--" + constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithDescriptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
-        [InlineData(full, typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
-        [InlineData(standard, typeof(ParameterOptionWithName), "--" + constant.Name, "")]
-        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.Name, "")]
-        [InlineData(standard, typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
+        [InlineData(full, typeof(ParameterOptionWithName), constant.Name, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameAttribute), constant.Name, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), constant.Name, "")]
+        [InlineData(full, typeof(ParameterOptionWithDescriptionAttribute), constant.ParameterOptionName, constant.Description)]
+        [InlineData(full, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.Description)]
+        [InlineData(standard, typeof(ParameterOptionWithName), constant.Name, "")]
+        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute),  constant.Name, "")]
+        [InlineData(standard, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.Description)]
         public void OptionNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string description)
         {
             var method = typeToTest.GetMethods().First();

--- a/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
@@ -27,13 +27,13 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         #region Command tests
         [Theory]
-        [InlineData(full, typeof(MethodEmptyMethod), constant.EmptyMethodName , "")]
-        [InlineData(full, typeof(MethodWithNameAttribute), constant.CommandOrOptionName , "")]
-        [InlineData(full, typeof(MethodWithNameInCommandAttribute), constant.CommandOrOptionName, "")]
+        [InlineData(full, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), "")]
+        [InlineData(full, typeof(MethodWithNameAttribute), constant.Name , "")]
+        [InlineData(full, typeof(MethodWithNameInCommandAttribute), constant.Name, "")]
         [InlineData(full, typeof(MethodWithDescriptionAttribute), constant.TestMethodName, constant.Description)]
         [InlineData(full, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, constant.Description)]
-        [InlineData(standard, typeof(MethodEmptyMethod), constant.EmptyMethodName, "")]
-        [InlineData(standard, typeof(MethodWithNameInCommandAttribute), constant.CommandOrOptionName, "")]
+        [InlineData(standard, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), "")]
+        [InlineData(standard, typeof(MethodWithNameInCommandAttribute), constant.Name, "")]
         [InlineData(standard, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, constant.Description)]
         public void NameAndDescriptionFromType(string useStrategy, Type typeToTest, string name, string description)
         {
@@ -128,13 +128,13 @@ namespace System.CommandLine.GeneralAppModel.Tests
         #region Option tests
 
         [Theory]
-        [InlineData(full, typeof(ParameterOptionWithName), "--" + constant.CommandOrOptionName, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameAttribute), "--" + constant.CommandOrOptionName, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.CommandOrOptionName, "")]
+        [InlineData(full, typeof(ParameterOptionWithName), "--" + constant.Name, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameAttribute), "--" + constant.Name, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.Name, "")]
         [InlineData(full, typeof(ParameterOptionWithDescriptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
         [InlineData(full, typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
-        [InlineData(standard, typeof(ParameterOptionWithName), "--" + constant.CommandOrOptionName, "")]
-        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.CommandOrOptionName, "")]
+        [InlineData(standard, typeof(ParameterOptionWithName), "--" + constant.Name, "")]
+        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.Name, "")]
         [InlineData(standard, typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
         public void OptionNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string description)
         {

--- a/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
@@ -28,17 +28,15 @@ namespace System.CommandLine.GeneralAppModel.Tests
         internal const int AllowedValuesAsIntThird = 7;
         internal const string ArgumentName = "Red";
         internal const string ArgumentName2 = "Blue";
-        internal const string OptionName = "east";
-        internal const string OptionName2 = "west";
+        internal const string OptionName = "East";
+        internal const string OptionName2 = "West";
         internal const string PropertyOptionName = "Prop";
         internal const string PropertyArgName = "Prop";
         internal const string DefaultValueString = "MyDefault";
         internal const int DefaultValueInt = 42;
-        internal const string EmptyMethodName = "empty-method";
-        internal const string EmptyTypeName = "empty-type";
 
-        internal const string TestMethodName = "method";
-        internal const string ParameterOptionName = "param";
+        internal const string TestMethodName = "Method";
+        internal const string ParameterOptionName = "Param";
         internal const string ParameterArgName = "Param";
 
         private readonly Strategy fullStrategy;
@@ -54,19 +52,16 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         #region CommandTests
         [Theory]
-        [InlineData(full, typeof(EmptyType), EmptyTypeName, "")]
-        [InlineData(full, typeof(TypeWithNameAttribute), CommandOrOptionName, "")]
-        [InlineData(full, typeof(TypeWithNameInCommandAttribute), CommandOrOptionName, "")]
+        [InlineData(full, typeof(EmptyType), nameof(EmptyType), "")]
+        [InlineData(full, typeof(TypeWithNameAttribute), Name, "")]
+        [InlineData(full, typeof(TypeWithNameInCommandAttribute), Name, "")]
         [InlineData(full, typeof(TypeWithDescriptionAttribute), nameof(TypeWithDescriptionAttribute), Description)]
         [InlineData(full, typeof(TypeWithDescriptionInCommandAttribute), nameof(TypeWithDescriptionInCommandAttribute), Description)]
-        [InlineData(standard, typeof(EmptyType), EmptyTypeName, "")]
-        [InlineData(standard, typeof(TypeWithNameInCommandAttribute), CommandOrOptionName, "")]
+        [InlineData(standard, typeof(EmptyType), nameof(EmptyType), "")]
+        [InlineData(standard, typeof(TypeWithNameInCommandAttribute), Name, "")]
         [InlineData(standard, typeof(TypeWithDescriptionInCommandAttribute), nameof(TypeWithDescriptionInCommandAttribute), Description)]
         public void CommandNameAndDescriptionFromType(string useStrategy, Type typeToTest, string name, string description)
         {
-            name = char.IsUpper(name[0])
-                    ? name.ToKebabCase()
-                    : name;
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, typeToTest);
 
             descriptor.Should().HaveName(name)
@@ -139,7 +134,6 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(standard, typeof(TypeWithTwoCommandsByDerivedType), "A", "B")]
         public void CommandWithSubCommands(string useStrategy, Type typeToTest, params string[] argNames)
         {
-            argNames = argNames.Select(x => x.ToKebabCase()).ToArray();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, typeToTest);
 
             descriptor.Should().HaveSubCommandsNamed(argNames);
@@ -196,7 +190,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(standard, typeof(PropertyOptionWithDescriptionInOptionAttribute), PropertyOptionName, Description)]
         public void OptionNameAndDescriptionFromProperty(string useStrategy, Type typeToTest, string name, string description)
         {
-            name = "--" + name.ToKebabCase();
+            name = "--" + name;
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, typeToTest);
 
             descriptor.Options.First()
@@ -286,7 +280,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(typeToTest);
             using var x = new AssertionScope();
             descriptor.Options.Count().Should().Be(1);
-            descriptor.Options.First().Name.Should().Be($"--{nameof(PropertiesThatArePublicAndPrivate.First).ToKebabCase()}");
+            descriptor.Options.First().Name.Should().Be($"--{nameof(PropertiesThatArePublicAndPrivate.First)}");
         }
 
         #endregion

--- a/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
@@ -140,12 +140,12 @@ namespace System.CommandLine.GeneralAppModel.Tests
         }
 
         [Theory]
-        [InlineData(full, typeof(TypeWithOnlyOneProperty), "--" + OptionName)]
-        [InlineData(full, typeof(TypeWithOneOptionByRemaining), "--" + OptionName)]
-        [InlineData(full, typeof(TypeWithTwoOptionsByRemaining), "--" + OptionName, "--" + OptionName2)]
-        [InlineData(standard, typeof(TypeWithOnlyOneProperty), "--" + OptionName)]
-        [InlineData(standard, typeof(TypeWithOneOptionByRemaining), "--" + OptionName)]
-        [InlineData(standard, typeof(TypeWithTwoOptionsByRemaining), "--" + OptionName, "--" + OptionName2)]
+        [InlineData(full, typeof(TypeWithOnlyOneProperty),OptionName)]
+        [InlineData(full, typeof(TypeWithOneOptionByRemaining), OptionName)]
+        [InlineData(full, typeof(TypeWithTwoOptionsByRemaining),OptionName,OptionName2)]
+        [InlineData(standard, typeof(TypeWithOnlyOneProperty), OptionName)]
+        [InlineData(standard, typeof(TypeWithOneOptionByRemaining), OptionName)]
+        [InlineData(standard, typeof(TypeWithTwoOptionsByRemaining), OptionName, OptionName2)]
         public void CommandWithSubOptions(string useStrategy, Type typeToTest, params string[] argNames)
         {
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, typeToTest);
@@ -190,7 +190,6 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(standard, typeof(PropertyOptionWithDescriptionInOptionAttribute), PropertyOptionName, Description)]
         public void OptionNameAndDescriptionFromProperty(string useStrategy, Type typeToTest, string name, string description)
         {
-            name = "--" + name;
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, typeToTest);
 
             descriptor.Options.First()
@@ -280,7 +279,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(typeToTest);
             using var x = new AssertionScope();
             descriptor.Options.Count().Should().Be(1);
-            descriptor.Options.First().Name.Should().Be($"--{nameof(PropertiesThatArePublicAndPrivate.First)}");
+            descriptor.Options.First().Name.Should().Be(nameof(PropertiesThatArePublicAndPrivate.First));
         }
 
         #endregion

--- a/ReflectionAppModel/CommandLineActivator.cs
+++ b/ReflectionAppModel/CommandLineActivator.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.ReflectionAppModel
 {
     public class CommandLineActivator : CommandLineActivatorBase
     {
-        protected override CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null)
+        public override CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null)
         {
             strategy ??= Strategy.Standard;
             return ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeof(TRoot));

--- a/Samples/MidSizePropertyBasedModel/ManageGlobalJson.cs
+++ b/Samples/MidSizePropertyBasedModel/ManageGlobalJson.cs
@@ -12,7 +12,8 @@ namespace System.CommandLine.Samples
     /// The actual rules for SDK selection depend on the highest SDK version installed 
     /// (or ever installed) on the machine.
     /// </remarks>
-    public class ManageGlobalJson
+    [DescriptionSource(typeof(ManageGlobalJson))]
+    public class ManageGlobalJson : IDescriptionSource
     {
         public DirectoryInfo StartPathArg { get; set; }
 
@@ -54,13 +55,17 @@ namespace System.CommandLine.Samples
                 => ManageGlobalJsonImplementation.Check(StartPathArg, Verbosity);
         }
 
+        public string GetDescription(string route)
+            => HelpText.TryGetValue(route, out var description)
+                ? description
+                : null;
 
         private const string startName = nameof(ManageGlobalJson);
         private const string findName = nameof(Find);
         private const string listName = nameof(List);
         private const string updateName = nameof(Update);
         private const string checkName = nameof(Check);
-        public Dictionary<string, string> HelpText = new Dictionary<string, string>
+        public Dictionary<string, string> HelpText = new Dictionary<string, string>()
             {
                 { startName, "Future global tool to manage global.json. See https://aka.ms/globaljson."},
                 { startName + $"+{nameof(StartPathArg)}","Location where processing should begin." },
@@ -85,5 +90,7 @@ namespace System.CommandLine.Samples
                 { nameof(RollForward) + $"+{nameof(RollForward.Disable)}", "Doesn't roll forward. Exact match required." },
 
             };
+
+
     }
 }

--- a/Samples/MidSizePropertyBasedModel/ManageGlobalJsonImplementation.cs
+++ b/Samples/MidSizePropertyBasedModel/ManageGlobalJsonImplementation.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine.ReflectionAppModel;
+﻿using System.CommandLine.GeneralAppModel;
+using System.CommandLine.ReflectionAppModel;
 using System.IO;
 
 namespace System.CommandLine.Samples

--- a/Samples/RuleExampleNamedAttr.Tests/MethodDescriptorMakerTests.cs
+++ b/Samples/RuleExampleNamedAttr.Tests/MethodDescriptorMakerTests.cs
@@ -98,9 +98,9 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData(typeof(MethodWithOnlyOneParameter), "--" + constant.OptionName)]
-        [InlineData(typeof(MethodWithOneOptionByRemaining), "--" + constant.OptionName)]
-        [InlineData(typeof(MethodWithTwoOptionsByRemaining), "--" + constant.OptionName, "--" + constant.OptionName2)]
+        [InlineData(typeof(MethodWithOnlyOneParameter), constant.OptionName)]
+        [InlineData(typeof(MethodWithOneOptionByRemaining), constant.OptionName)]
+        [InlineData(typeof(MethodWithTwoOptionsByRemaining), constant.OptionName, constant.OptionName2)]
         public void CommandWithSubOptions(Type typeToTest, params string[] argNames)
         {
             var method = typeToTest.GetMethods().First();
@@ -114,11 +114,11 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         #region Option tests
 
         [Theory]
-        [InlineData(typeof(ParameterOptionWithName), "--" + constant.Name, "")]
-        [InlineData(typeof(ParameterOptionWithNameAttribute), "--" + constant.Name, "")]
-        [InlineData(typeof(ParameterOptionWithNameInOptionAttribute), "--" + constant.Name, "")]
-        [InlineData(typeof(ParameterOptionWithDescriptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
-        [InlineData(typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
+        [InlineData(typeof(ParameterOptionWithName), constant.Name, "")]
+        [InlineData(typeof(ParameterOptionWithNameAttribute), constant.Name, "")]
+        [InlineData(typeof(ParameterOptionWithNameInOptionAttribute), constant.Name, "")]
+        [InlineData(typeof(ParameterOptionWithDescriptionAttribute), constant.ParameterOptionName, constant.Description)]
+        [InlineData(typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.Description)]
         public void OptionNameAndDescriptionFromParameter(Type typeToTest, string name, string description)
         {
             var method = typeToTest.GetMethods().First();

--- a/Samples/RuleExampleNamedAttr.Tests/MethodDescriptorMakerTests.cs
+++ b/Samples/RuleExampleNamedAttr.Tests/MethodDescriptorMakerTests.cs
@@ -33,7 +33,6 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         [InlineData(typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, constant.Description)]
         public void NameAndDescriptionFromType(Type typeToTest, string name, string description)
         {
-            name = name.ToKebabCase();
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, method);
 
@@ -122,7 +121,6 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         [InlineData(typeof(ParameterOptionWithDescriptionInOptionAttribute), "--" + constant.ParameterOptionName, constant.Description)]
         public void OptionNameAndDescriptionFromParameter(Type typeToTest, string name, string description)
         {
-            name = "--" + name.ToKebabCase();
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, method);
 

--- a/Samples/RuleExampleNamedAttr.Tests/TypeDescriptorMakerTests.cs
+++ b/Samples/RuleExampleNamedAttr.Tests/TypeDescriptorMakerTests.cs
@@ -27,8 +27,8 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         internal const int AllowedValuesAsIntThird = 7;
         internal const string ArgumentName = "Red";
         internal const string ArgumentName2 = "Blue";
-        internal const string OptionName = "east";
-        internal const string OptionName2 = "west";
+        internal const string OptionName = "East";
+        internal const string OptionName2 = "West";
         internal const string PropertyOptionName = "Prop";
         internal const string PropertyArgName = "Prop";
         internal const string DefaultValueString = "MyDefault";
@@ -55,7 +55,6 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         [InlineData(typeof(TypeWithDescriptionInCommandAttribute), nameof(TypeWithDescriptionInCommandAttribute), Description)]
         public void CommandNameAndDescriptionFromType(Type typeToTest, string name, string description)
         {
-            name = name.ToKebabCase();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeToTest);
 
             descriptor.Should().HaveName(name)
@@ -115,8 +114,8 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithOneCommandByDerivedType), "a")]
-        [InlineData(typeof(TypeWithTwoCommandsByDerivedType), "a", "b")]
+        [InlineData(typeof(TypeWithOneCommandByDerivedType), "A")]
+        [InlineData(typeof(TypeWithTwoCommandsByDerivedType), "A", "B")]
         public void CommandWithSubCommands(Type typeToTest, params string[] argNames)
         {
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeToTest);
@@ -147,7 +146,7 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         [InlineData(typeof(PropertyOptionWithDescriptionInOptionAttribute), PropertyOptionName, Description)]
         public void OptionNameAndDescriptionFromProperty(Type typeToTest, string name, string description)
         {
-            name = "--" + name.ToKebabCase();
+            name = "--" + name;
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeToTest);
 
             descriptor.Options.First()

--- a/Samples/RuleExampleNamedAttr.Tests/TypeDescriptorMakerTests.cs
+++ b/Samples/RuleExampleNamedAttr.Tests/TypeDescriptorMakerTests.cs
@@ -124,9 +124,9 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData(typeof(TypeWithOnlyOneProperty), "--" + OptionName)]
-        [InlineData(typeof(TypeWithOneOptionByRemaining), "--" + OptionName)]
-        [InlineData(typeof(TypeWithTwoOptionsByRemaining), "--" + OptionName, "--" + OptionName2)]
+        [InlineData(typeof(TypeWithOnlyOneProperty),OptionName)]
+        [InlineData(typeof(TypeWithOneOptionByRemaining), OptionName)]
+        [InlineData(typeof(TypeWithTwoOptionsByRemaining), OptionName, OptionName2)]
         public void CommandWithSubOptions(Type typeToTest, params string[] argNames)
         {
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeToTest);
@@ -146,7 +146,6 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         [InlineData(typeof(PropertyOptionWithDescriptionInOptionAttribute), PropertyOptionName, Description)]
         public void OptionNameAndDescriptionFromProperty(Type typeToTest, string name, string description)
         {
-            name = "--" + name;
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(strategy, typeToTest);
 
             descriptor.Options.First()

--- a/Samples/UsageViaInvoke.Tests/UsageTests.cs
+++ b/Samples/UsageViaInvoke.Tests/UsageTests.cs
@@ -2,6 +2,8 @@
 using Microsoft.VisualStudio.TestPlatform.TestHost;
 using Xunit;
 using System.CommandLine;
+using System.CommandLine.Samples;
+using System.CommandLine.ReflectionAppModel;
 
 namespace System.CommandLine.GeneralAppModel.Tests
 {
@@ -14,6 +16,72 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var x = Samples.Program.Main(arg.Split(' '));
             x.Should().Be(7);
         }
+
+        /// <summary>
+        /// The strategy report let's you know what features are available as you 
+        /// build your model - what rules are in play
+        /// </summary>
+        [Fact]
+        public void StrategyReportShouldBeLong()
+        {
+            var strategy = new Strategy().SetStandardRules();
+            var report = strategy.Report();
+            report.Length.Should().BeGreaterThan(1000);
+        }
+
+        /// <summary>
+        /// The Descriptor report describes the interim model that captures your intent 
+        /// </summary>
+        [Fact]
+        public void DescriptorReportShouldBeLong()
+        {
+            var strategy = new Strategy().SetStandardRules();
+            var activator = new CommandLineActivator();
+            var descriptor = activator.GetCommandDescriptor<ManageGlobalJson>(strategy);
+            var report = descriptor.Report(0);
+            report.Length.Should().BeGreaterThan(1000);
+        }
+
+        /// <summary>
+        /// If we create a Symbol report it would describe the System.CommandLine model
+        /// created. 
+        /// generation. 
+        /// </summary>
+        /// <remarks>
+        /// While this would be useful, it would probably have to be against an
+        /// in memory object, and may be hard (or possibly easy) to do with source.
+        /// <br/>
+        /// All of the user impact will be captured in the descriptor. Rules, which 
+        /// may result in incorrect user intent (user bugs) will be in the descriptor.
+        /// <br/>
+        /// Put a different way, Descriptor bugs may be user bugs. Symbol/CommandLine
+        /// bugs are the fault of the AppModel, or possibly user misunderstanding what
+        /// is contained in the AppModel. For example, nailing down "Name"
+        /// </remarks>
+        [Fact]
+        public void SymbolReportMayBeUseful()
+        {
+            var strategy = new Strategy().SetStandardRules();
+            var activator = new CommandLineActivator();
+            var descriptor = activator.GetCommandDescriptor<ManageGlobalJson>(strategy);
+            var report = descriptor.Report(0);
+            report.Length.Should().BeGreaterThan(1000);
+        }
+
+
+        /// <summary>
+        /// We may want a log of what rules are applied to create the Descriptor. It's one thing
+        /// to look at the rules/strategy and predict how your code created the descriptors, 
+        /// and another to actually have a log of which rules were used. 
+        /// </summary>
+        [Fact]
+        public void LogMightBeUseful()
+        {
+            var strategy = new Strategy().SetStandardRules();
+            var report = strategy.Report();
+            report.Length.Should().BeGreaterThan(1000);
+        }
+
 
 
     }

--- a/Samples/UsageViaInvoke.Tests/UsageTests.cs
+++ b/Samples/UsageViaInvoke.Tests/UsageTests.cs
@@ -38,7 +38,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var strategy = new Strategy().SetStandardRules();
             var activator = new CommandLineActivator();
             var descriptor = activator.GetCommandDescriptor<ManageGlobalJson>(strategy);
-            var report = descriptor.Report(0);
+            var report = descriptor.Report(0, VerbosityLevel.Detailed );
             report.Length.Should().BeGreaterThan(1000);
         }
 
@@ -61,11 +61,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Fact]
         public void SymbolReportMayBeUseful()
         {
-            var strategy = new Strategy().SetStandardRules();
-            var activator = new CommandLineActivator();
-            var descriptor = activator.GetCommandDescriptor<ManageGlobalJson>(strategy);
-            var report = descriptor.Report(0);
-            report.Length.Should().BeGreaterThan(1000);
+  
         }
 
 
@@ -77,9 +73,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Fact]
         public void LogMightBeUseful()
         {
-            var strategy = new Strategy().SetStandardRules();
-            var report = strategy.Report();
-            report.Length.Should().BeGreaterThan(1000);
+         
         }
 
 

--- a/System.CommandLine.GeneralAppModel.Tests/CommandMakerTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/CommandMakerTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.CommandLine.GeneralAppModel.Tests.Maker;
+using System.CommandLine.Parsing;
 using System.Linq;
 using Xunit;
 
@@ -7,9 +8,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
 {
     public class CommandMakerTests
     {
-        public const string name = "Fred";
-        public const string name2 = "Bill";
-        public const string nameForEmpty = "NameIsRequired";
+        public const string name = "fred";
+        public const string name2 = "bill";
+        public const string nameForEmpty = "name-is-required";
         public const string desc = "This is awesome!";
         public const string aliasAsStringMuitple = "x,y,z";
         public const string aliasAsStringSingle = "a";
@@ -38,7 +39,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
                           ? new string[] { }
                           : aliasesAsString.Split(',').Select(s => s.Trim()).ToArray();
             var data = new CommandBasicsTestData(name, description, aliases, isHidden, treatUnmatchedTokensAsErrors);
-            var command = new Command(name);
+            var command = new Command(name.ToKebabCase());
             CommandMaker.FillCommand(command, data.Descriptor);
             data.Check(command);
         }

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
@@ -143,7 +143,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
                                  .UseDefaults()
                                  .Build();
 
-            var parseResult = parser.Parse($"DummyCommandName {HelloTo}");
+            var parseResult = parser.Parse($"dummy-command-name {HelloTo}");
             parseResult.Errors.Should().BeEmpty();
 
             var ret = parser.Invoke(HelloTo);
@@ -178,7 +178,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
                                  .UseDefaults()
                                  .Build();
 
-            var parseResult = parser.Parse($"DummyCommandName");
+            var parseResult = parser.Parse($"dummy-command-name");
             parseResult.Errors.Should().BeEmpty();
 
             var ret = parser.Invoke("");
@@ -230,7 +230,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
                                  .Build();
 
             string commandLine = $"{HelloTo} --all-caps";
-            var parseResult = parser.Parse("DummyCommandName " + commandLine);
+            var parseResult = parser.Parse("dummy-command-name " + commandLine);
             parseResult.Errors.Should().BeEmpty();
 
             var ret = parser.Invoke(commandLine);

--- a/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
@@ -113,5 +113,13 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var report = strategy.Report();
             report.Length.Should().BeGreaterThan(4500);
         }
+
+        [Fact]
+        public void StandardStrategyReportIsAboutTheRightLength()
+        {
+            var strategy = new Strategy().SetStandardRules();
+            var report = strategy.Report();
+            report.Length.Should().BeGreaterThan(4500);
+        }
     }
 }

--- a/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
@@ -119,7 +119,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         {
             var strategy = new Strategy().SetStandardRules();
             var report = strategy.Report();
-            report.Length.Should().BeGreaterThan(4500);
+            report.Length.Should().BeGreaterThan(4000);
         }
     }
 }

--- a/System.CommandLine.GeneralAppModel/Attributes/DescriptionSourceAttribute.cs
+++ b/System.CommandLine.GeneralAppModel/Attributes/DescriptionSourceAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+   public  class DescriptionSourceAttribute : Attribute 
+    {
+        public DescriptionSourceAttribute(Type descriptionSource)
+        {
+            if (!typeof(IDescriptionSource ).IsAssignableFrom (descriptionSource ))
+            {
+                throw new InvalidOperationException("Description source must implement IDescriptionSource interface");
+            }
+            DescriptionSource = descriptionSource;
+        }
+
+        public Type DescriptionSource { get; }
+    }
+}

--- a/System.CommandLine.GeneralAppModel/CommandLineActivatorBase.cs
+++ b/System.CommandLine.GeneralAppModel/CommandLineActivatorBase.cs
@@ -12,7 +12,13 @@ namespace System.CommandLine.GeneralAppModel
 {
     public abstract class CommandLineActivatorBase
     {
-        protected abstract CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null);
+        /// <summary>
+        /// This test is public for testing purposes
+        /// </summary>
+        /// <typeparam name="TRoot"></typeparam>
+        /// <param name="strategy"></param>
+        /// <returns></returns>
+        public abstract CommandDescriptor GetCommandDescriptor<TRoot>(Strategy? strategy = null);
 
         public int Invoke<TRoot>(string[] args, Strategy? strategy = null)
         {

--- a/System.CommandLine.GeneralAppModel/CommandMaker.cs
+++ b/System.CommandLine.GeneralAppModel/CommandMaker.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.GeneralAppModel
         {
             var _ = descriptor.Name ?? throw new InvalidOperationException("The name for a non-root command cannot be null");
 
-            return MakeCommandInternal(new Command(descriptor.Name), descriptor);
+            return MakeCommandInternal(new Command(descriptor.Name.ToKebabCase()), descriptor);
         }
 
         public static ModelBinder? MakeModelBinder(CommandDescriptor descriptor)

--- a/System.CommandLine.GeneralAppModel/CommandMaker.cs
+++ b/System.CommandLine.GeneralAppModel/CommandMaker.cs
@@ -98,15 +98,16 @@ namespace System.CommandLine.GeneralAppModel
 
         protected override Argument MakeArgument(ArgumentDescriptor descriptor)
         {
-            var arg = new Argument(descriptor.Name)
+            if (descriptor is null)
+            {
+                throw new InvalidOperationException("The descriptor cannot be null");
+            }
+            var arg = new Argument(descriptor.Name ?? string.Empty)
             {
                 ArgumentType = descriptor.ArgumentType.GetArgumentType<Type>() // need work here for Roslyn source generation
             };
             AddAliases(arg, descriptor.Aliases);
-            if (descriptor.Arity != null)
-            {
-                arg.Arity = new ArgumentArity(descriptor.Arity.MinimumCount, descriptor.Arity.MaximumCount);
-            }
+            AddArity(descriptor, arg);
             arg.Description = descriptor.Description;
             arg.IsHidden = descriptor.IsHidden;
             if (descriptor.DefaultValue != null)
@@ -115,6 +116,24 @@ namespace System.CommandLine.GeneralAppModel
             }
             descriptor.SetSymbol(arg);
             return arg;
+
+           static void AddArity(ArgumentDescriptor descriptor, Argument arg)
+            {
+                if (descriptor.Arity != null)
+                {
+                    var minCount = descriptor.Arity.MinimumCount;
+                    minCount = descriptor.Required && minCount == 0
+                                ? 1
+                                : minCount;
+                    arg.Arity = new ArgumentArity(minCount, descriptor.Arity.MaximumCount);
+                }
+                else
+                {
+                    arg.Arity =  new ArgumentArity(
+                                descriptor.Required ? 1: 0,
+                                arg.Arity.MaximumNumberOfValues);
+                }
+            }
         }
 
         protected override ModelBinder? GetModelBinderForType(Type type, CommandDescriptor commandDescriptor)

--- a/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
+++ b/System.CommandLine.GeneralAppModel/DescriptorMakerBase.cs
@@ -37,7 +37,7 @@ namespace System.CommandLine.GeneralAppModel
 
         protected Strategy Strategy { get; }
         protected object DataSource { get; }
-
+        private IEnumerable<IDescriptionSource> descriptionSources = new List<IDescriptionSource>();
 
         private (IEnumerable<Candidate> optionItems, IEnumerable<Candidate> subCommandItems, IEnumerable<Candidate> argumentItems)
              ClassifyChildren(IEnumerable<Candidate> candidates, ISymbolDescriptor commandDescriptor)
@@ -85,9 +85,18 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         protected CommandDescriptor CommandFrom(ISymbolDescriptor parentSymbolDescriptor)
-            => GetCommand(DescriptorMakerSpecificSourceBase.Tools.CreateCandidate(DataSource), parentSymbolDescriptor);
+        {
+            var ruleSet = Strategy.DescriptorContextRules;
+            var candidate = DescriptorMakerSpecificSourceBase.Tools.CreateCandidate(DataSource);
+            var sources = ruleSet.DescriptionSourceRules.GetAllValues<Type>(new EmptySymbolDescriptor(), candidate, parentSymbolDescriptor);
+            descriptionSources = sources
+                                    .Select(x => Activator.CreateInstance(x))
+                                    .OfType<IDescriptionSource>()
+                                    .ToList();
+            return GetCommand(candidate, parentSymbolDescriptor);
+        }
 
-        protected CommandDescriptor GetCommand(Candidate candidate, ISymbolDescriptor parentSymbolDescriptor)
+        private CommandDescriptor GetCommand(Candidate candidate, ISymbolDescriptor parentSymbolDescriptor)
         {
             var descriptor = new CommandDescriptor(parentSymbolDescriptor, candidate.Item);
             var ruleSet = Strategy.CommandRules;
@@ -201,17 +210,54 @@ namespace System.CommandLine.GeneralAppModel
                         : aliases;
             descriptor.Name = GetName(descriptor, name);
             descriptor.Aliases = aliases.ToList();
-            descriptor.Description = ruleSet.DescriptionRules.GetFirstOrDefaultValue<string>(descriptor, candidate, parentSymbolDescriptor) ?? string.Empty;
+            descriptor.Description = GetDescription(descriptor, ruleSet.DescriptionRules, candidate, parentSymbolDescriptor);
             descriptor.IsHidden = ruleSet.IsHiddenRules.GetFirstOrDefaultValue<bool>(descriptor, candidate, parentSymbolDescriptor);
         }
 
-        private string GetName(SymbolDescriptor symbol, string name) 
+        private string GetName(SymbolDescriptor symbol, string name)
             => symbol switch
-                {
-                    OptionDescriptor _ => name.StartsWith("--") ? name : "--" + name.ToKebabCase(),
-                    CommandDescriptor _ => name.ToKebabCase(),
-                    _ => name
-                };
+            {
+                OptionDescriptor _ => name.StartsWith("--") ? name : "--" + name,
+                CommandDescriptor _ => name,
+                _ => name
+            };
+
+        private string GetDescription(SymbolDescriptor descriptor, RuleGroup<IRuleGetValue<string>> rules, Candidate candidate, ISymbolDescriptor parentSymbolDescriptor)
+        {
+            var description = rules.GetFirstOrDefaultValue<string>(descriptor, candidate, parentSymbolDescriptor);
+            if (!string.IsNullOrWhiteSpace(description) && !(description is null))
+            {
+                return description;
+            }
+            var route = GetRoute(descriptor, parentSymbolDescriptor);
+            var source = descriptionSources
+                    .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x.GetDescription(route)));
+            return source is null
+                    ? string.Empty
+                    : source.GetDescription(route);
+        }
+
+        private string GetRoute(SymbolDescriptor descriptor, ISymbolDescriptor parentSymbolDescriptor)
+        {
+            var parent = GetParentRoute(parentSymbolDescriptor);
+            parent = parent.EndsWith("+")
+                        ? parent.Substring(0,parent.Length-1)
+                        : parent;
+
+            var plus = string.IsNullOrEmpty(parent) ? string.Empty : "+";
+            return $"{parent}{plus}{descriptor.Name}";
+        }
+
+        private string GetParentRoute(ISymbolDescriptor parentSymbolDescriptor)
+        {
+            if (parentSymbolDescriptor is SymbolDescriptor parentDescriptor)
+            {
+                var parent = GetParentRoute(parentDescriptor.ParentSymbolDescriptorBase);
+                var plus = string.IsNullOrEmpty(parent) ? string.Empty : "+";
+                return $"{parent}{plus}{parentDescriptor.Name}";
+            }
+            return string.Empty;
+        }
 
         private void ReplaceAbstractRules(Strategy strategy, DescriptorMakerSpecificSourceBase tools)
         {

--- a/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
@@ -19,7 +19,7 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public DefaultValueDescriptor? DefaultValue { get; set; }
         public bool Required { get; set; }
 
-        public override string ReportInternal(int tabsCount)
+        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity )
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             return $"{whitespace}Arity:{Arity}" +

--- a/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
@@ -12,12 +12,21 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         }
 
         public ArityDescriptor? Arity { get; set; }
-        //TODO: AllowedValues aren't supported in DescriptorMakerBase or tests
+        //TODO: AllowedValues aren't yet supported in DescriptorMakerBase or tests
         public List<object> AllowedValues { get; } = new List<object>();
-        // TODO: Consider how ArgumentType works when coming from JSON. 
+        // TODO: Consider how ArgumentType works when coming from JSON. If we do Json
         public ArgTypeInfo ArgumentType { get; }
         public DefaultValueDescriptor? DefaultValue { get; set; }
         public bool Required { get; set; }
 
+        public override string ReportInternal(int tabsCount)
+        {
+            string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
+            return $"{whitespace}Arity:{Arity}" +
+                   $"{whitespace}AllowedValues:{Name}" +
+                   $"{whitespace}ArgumentType:{ArgumentType}" +
+                   $"{whitespace}DefaultValue:{DefaultValue}" +
+                   $"{whitespace}Required:{Required}";
+        }
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
@@ -10,7 +10,7 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
     {
         public CommandDescriptor(ISymbolDescriptor parentSymbolDescriptorBase,
                                  object? raw)
-            : base(parentSymbolDescriptorBase, raw, SymbolType.Command) { }
+            : base(parentSymbolDescriptorBase, raw,  SymbolType.Command) { }
 
         public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
         public List<ArgumentDescriptor> Arguments { get; } = new List<ArgumentDescriptor>();
@@ -18,13 +18,13 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public InvokeMethodInfo? InvokeMethod { get; set; } // in Reflection models, this is a MethodInfo, in Roslyn it will be something else
         public List<CommandDescriptor> SubCommands { get; } = new List<CommandDescriptor>();
 
-        public override string ReportInternal(int tabsCount)
+        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity )
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             return $"{whitespace}TreatUnmatchedTokensAsErrors:{TreatUnmatchedTokensAsErrors}" +
-                   $"{whitespace}SubCommands:{string.Join("", SubCommands.Select(x => x.Report(tabsCount + 1)))}" +
-                   $"{whitespace}Options:{string.Join("", Options.Select(x => x.Report(tabsCount + 1)))}" +
-                   $"{whitespace}Arguments:{string.Join("", Arguments.Select(x => x.Report(tabsCount + 1)))}";
+                   $"{whitespace}SubCommands:{string.Join("", SubCommands.Select(x => x.Report(tabsCount + 1, verbosity)))}" +
+                   $"{whitespace}Options:{string.Join("", Options.Select(x => x.Report(tabsCount + 1, verbosity)))}" +
+                   $"{whitespace}Arguments:{string.Join("", Arguments.Select(x => x.Report(tabsCount + 1, verbosity)))}";
         }
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.CommandLine.Binding;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Reflection;
 
 namespace System.CommandLine.GeneralAppModel.Descriptors
@@ -17,5 +18,13 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public InvokeMethodInfo? InvokeMethod { get; set; } // in Reflection models, this is a MethodInfo, in Roslyn it will be something else
         public List<CommandDescriptor> SubCommands { get; } = new List<CommandDescriptor>();
 
+        public override string ReportInternal(int tabsCount)
+        {
+            string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
+            return $"{whitespace}TreatUnmatchedTokensAsErrors:{TreatUnmatchedTokensAsErrors}" +
+                   $"{whitespace}SubCommands:{string.Join("", SubCommands.Select(x => x.Report(tabsCount + 1)))}" +
+                   $"{whitespace}Options:{string.Join("", Options.Select(x => x.Report(tabsCount + 1)))}" +
+                   $"{whitespace}Arguments:{string.Join("", Arguments.Select(x => x.Report(tabsCount + 1)))}";
+        }
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
@@ -3,5 +3,6 @@
     public interface ISymbolDescriptor
     {
         SymbolType SymbolType { get; }
+        string Report(int tabsCount);
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
@@ -1,8 +1,17 @@
-﻿namespace System.CommandLine.GeneralAppModel
+﻿using System.Collections.Generic;
+
+namespace System.CommandLine.GeneralAppModel
 {
     public interface ISymbolDescriptor
     {
         SymbolType SymbolType { get; }
-        string Report(int tabsCount);
+        object? Raw { get; }
+        IEnumerable<string>? Aliases { get; }
+        //TODO: Understand raw aliases: public IReadOnlyList<string> RawAliases { get; }
+        string? Description { get; }
+        string? Name { get; }
+        string? CommandLineName { get; }
+        bool IsHidden { get; set; }
+        string Report(int tabsCount, VerbosityLevel verbosity);
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
@@ -4,14 +4,15 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
 {
     public class OptionDescriptor : SymbolDescriptor
     {
-        public OptionDescriptor(ISymbolDescriptor parentSymbolDescriptorBase,
+        public OptionDescriptor(ISymbolDescriptor parentSymbolDescriptorBase, 
                                 object? raw)
-            : base(parentSymbolDescriptorBase, raw, SymbolType.Option) { }
+            : base(parentSymbolDescriptorBase, raw,  SymbolType.Option) { }
 
         public List<ArgumentDescriptor> Arguments { get; } = new List<ArgumentDescriptor>();
         public bool Required { get; set; }
+        public string? Prefix { get; set; }
 
-        public override string ReportInternal(int tabsCount)
+        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             return $"{whitespace}Required:{Required}" ;

--- a/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
@@ -11,5 +11,11 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public List<ArgumentDescriptor> Arguments { get; } = new List<ArgumentDescriptor>();
         public bool Required { get; set; }
 
+        public override string ReportInternal(int tabsCount)
+        {
+            string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
+            return $"{whitespace}Required:{Required}" ;
+        }
+
     }
 }

--- a/System.CommandLine.GeneralAppModel/Descriptors/SymbolDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/SymbolDescriptor.cs
@@ -7,10 +7,16 @@ namespace System.CommandLine.GeneralAppModel
 
     public class EmptySymbolDescriptor : ISymbolDescriptor
     {
-        public SymbolType SymbolType { get; } = SymbolType.All;
+        public SymbolType SymbolType { get; }
+        public object? Raw { get; }
+        public IEnumerable<string>? Aliases { get; }
+        public string? Description { get; }
+        public string? Name { get; }
+        public string? CommandLineName { get; }
+        public bool IsHidden { get; set; }
 
-        public string Report(int tabsCount)
-            => "Empty SymbolDescriptor - used for testing";
+        public  string Report(int tabsCount, VerbosityLevel verbosity)
+            => "Empty SymbolDescriptor - used for testing";   
     }
 
     public abstract class SymbolDescriptor : ISymbolDescriptor
@@ -26,9 +32,9 @@ namespace System.CommandLine.GeneralAppModel
             SymbolType = symbolType;
         }
 
-        public abstract string ReportInternal(int tabsCount);
+        public abstract string ReportInternal(int tabsCount, VerbosityLevel verbosity);
 
-        public string Report(int tabsCount)
+        public virtual string Report(int tabsCount, VerbosityLevel verbosity)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             string whitespace2 = CoreExtensions.NewLineWithTabs(tabsCount+1);
@@ -37,7 +43,7 @@ namespace System.CommandLine.GeneralAppModel
                    $"{whitespace2}Description:{Description }" +
                    $"{whitespace2}Aliases:{Aliases }" +
                    $"{whitespace2}IsHidden:{IsHidden  }" +
-                   ReportInternal(tabsCount+1) +
+                   ReportInternal(tabsCount+1, verbosity) +
                    $"{whitespace2}Raw:{ReportRaw(Raw)}" +
                    $"{whitespace2}Symbol:{ReportBound(SymbolToBind)}";
 
@@ -87,6 +93,7 @@ namespace System.CommandLine.GeneralAppModel
         // TODO: Understand raw aliases: public IReadOnlyList<string> RawAliases { get; }
         public string? Description { get; set; }
         public virtual string? Name { get; set; }
+        public string? CommandLineName { get; }
         public bool IsHidden { get; set; }
     }
 }

--- a/System.CommandLine.GeneralAppModel/Extensions.cs
+++ b/System.CommandLine.GeneralAppModel/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.CommandLine.GeneralAppModel.Descriptors;
+using System.CommandLine.GeneralAppModel.Rules;
 using System.Linq;
 using System.Reflection;
 
@@ -41,14 +42,45 @@ namespace System.CommandLine.GeneralAppModel
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             string indentedWhitespace = CoreExtensions.NewLineWithTabs(tabsCount + 1);
-            return $"{ whitespace}To determine {what}  { string.Join("", ruleGroup.Select(r => indentedWhitespace + r.RuleDescription<TRule>() + $" ({r.GetType().Name})"))}";
+            return $"{ whitespace}To determine {what}:  { string.Join("", ruleGroup.Select(r => indentedWhitespace + r.RuleDescription<TRule>() + $" ({r.GetType().NameWithGenericArguments()})"))}";
         }
 
-        public static string ProperAnOrA(this string s)
+        public static string PrefixAnOrA(this string s)
         {
             return new char[] { 'A', 'E', 'I', 'O', 'U', 'a', 'e', 'i', 'o', 'u' }.Contains(s.First())
                     ? "an " + s
                     : "a " + s;
+        }
+
+        public static string PrefixUpperAnOrA(this string s)
+        {
+            return new char[] { 'A', 'E', 'I', 'O', 'U', 'a', 'e', 'i', 'o', 'u' }.Contains(s.First())
+                    ? "An " + s
+                    : "A " + s;
+        }
+
+        public static string NameWithGenericArguments(this Type type)
+        {
+            return type.IsGenericType
+                ? NameWithoutGeneric(type) + GenericArguments(type)
+                : type.Name;
+
+            static string NameWithoutGeneric(Type type)
+            {
+                var name = type.Name;
+                var pos = name.IndexOf("`");
+                return pos >= 0
+                    ? name.Substring(0, pos)
+                    : name;
+            }
+
+            static string GenericArguments(Type type)
+            {
+                return "<" + string.Join(", ", type
+                                    .GetGenericArguments()
+                                    .Select(x => x.Name)) +
+                            ">";
+            }
         }
 
         public static void Assert(this List<ValidationFailureInfo> messages, bool isOK, string id, string path, string message)

--- a/System.CommandLine.GeneralAppModel/IDescriptionSource.cs
+++ b/System.CommandLine.GeneralAppModel/IDescriptionSource.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+ public    interface IDescriptionSource
+    {
+        string GetDescription(string route);
+    }
+}

--- a/System.CommandLine.GeneralAppModel/RuleSet/RuleSetDescriptorContext.cs
+++ b/System.CommandLine.GeneralAppModel/RuleSet/RuleSetDescriptorContext.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public class RuleSetDescriptorContext : RuleSetBase
+    {
+        public RuleGroup<IRuleGetValues<Type>> DescriptionSourceRules { get; } 
+                = new RuleGroup<IRuleGetValues<Type>>();
+
+        public override void ReplaceAbstractRules(DescriptorMakerSpecificSourceBase tools)
+        {
+            DescriptionSourceRules.ReplaceAbstractRules(tools);
+        }
+
+        public override string Report(int tabsCount)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSelectSymbols.cs
+++ b/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSelectSymbols.cs
@@ -22,7 +22,7 @@ namespace System.CommandLine.GeneralAppModel
                                 .OfType<IRuleGetCandidates>()
                                 .Where(x => x.SymbolType == symbolType)
                                 .ToList();
-            return rules                 
+            return rules
                     .SelectMany(r => r.GetCandidates(candidates, commandDescriptor))
                     .Distinct(new CompareRaw())
                     .ToList();
@@ -30,10 +30,10 @@ namespace System.CommandLine.GeneralAppModel
 
         private class CompareRaw : IEqualityComparer<Candidate>
         {
-            public bool Equals(Candidate x, Candidate y) 
+            public bool Equals(Candidate x, Candidate y)
                 => x.Item == y.Item;
 
-            public int GetHashCode(Candidate obj) 
+            public int GetHashCode(Candidate obj)
                 => obj.Item.GetHashCode();
         }
 
@@ -45,7 +45,15 @@ namespace System.CommandLine.GeneralAppModel
         public override string Report(int tabsCount)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
-            return string.Join("", Rules.Select(r => whitespace + $"Is {r.SymbolType.ToString().ProperAnOrA()} if {r.RuleDescription<IRuleGetCandidates>()} ({r.GetType().Name})"));
+            return string.Join("", Rules.Select(r => whitespace + 
+                                    $"{ProperName(r.SymbolType)} if " +
+                                    $"{r.RuleDescription<IRuleGetCandidates>()} " +
+                                    $"({r.GetType().NameWithGenericArguments()})"));
+
+            string ProperName(SymbolType symbolType)
+            {
+                return symbolType.ToString();
+            }
         }
     }
 }

--- a/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSymbol.cs
+++ b/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSymbol.cs
@@ -4,7 +4,7 @@ namespace System.CommandLine.GeneralAppModel
 {
     public abstract class RuleSetSymbol : RuleSetBase
     {
-        
+
         public RuleGroup<IRuleGetValue<string>> DescriptionRules { get; } = new RuleGroup<IRuleGetValue<string>>();
 
         /// <summary>
@@ -13,31 +13,6 @@ namespace System.CommandLine.GeneralAppModel
         public RuleGroup<IRuleGetValue<string>> NameRules { get; } = new RuleGroup<IRuleGetValue<string>>();
         public RuleGroup<IRuleGetValues<string[]>> AliasRules { get; } = new RuleGroup<IRuleGetValues<string[]>>();
         public RuleGroup<IRuleGetValue<bool>> IsHiddenRules { get; } = new RuleGroup<IRuleGetValue<bool>>();
-
-        //public IEnumerable<T> GetSymbols<T>(SymbolType requestedSymbolType, IEnumerable<T> items, SymbolDescriptor parentSymbolDescriptor)
-        //{
-        //    throw new NotImplementedException();
-        //}
-
-        //public void AddDescriptionRule(IRuleGetValues<string> descriptionRule)
-        //{
-        //    DescriptionRules.Add(descriptionRule);
-        //}
-
-        //public void AddNameRule(IRuleGetValues<string> nameRule)
-        //{
-        //    NameRules.Add(nameRule);
-        //}
-
-        //public void AddAliasesRule(IRuleGetValues<string[]> aliasesRule)
-        //{
-        //    AliasRules.Add(aliasesRule);
-        //}
-
-        //public void AddHiddenRule(IRuleGetValues<bool> isHiddenRule)
-        //{
-        //    IsHiddenRules.Add(isHiddenRule);
-        //}
 
         public override void ReplaceAbstractRules(DescriptorMakerSpecificSourceBase tools)
         {
@@ -50,7 +25,7 @@ namespace System.CommandLine.GeneralAppModel
         public override string Report(int tabsCount)
         {
             return NameRules.ReportRuleGroup(tabsCount, "the name")
-                    + DescriptionRules.ReportRuleGroup(tabsCount, "the description" )
+                    + DescriptionRules.ReportRuleGroup(tabsCount, "the description")
                     + AliasRules.ReportRuleGroup(tabsCount, "aliases")
                     + IsHiddenRules.ReportRuleGroup(tabsCount, "whether to hide this in the CLI");
         }

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeRule.cs
@@ -28,6 +28,6 @@ namespace System.CommandLine.GeneralAppModel
         public override string RuleDescription<TIRuleSet>()
            => (typeof(IRuleGetValue<string>).IsAssignableFrom(typeof(TIRuleSet))
                 ? "If " : "")
-            + $"there is an attribute named '{typeof(TAttribute).Name}'";
+            + $"there is an attribute named '{typeof(TAttribute).NameWithGenericArguments()}'";
     }
 }

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeWithComplexValueRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeWithComplexValueRule.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         public override string RuleDescription<TIRuleSet>()
-            => $"If there is an attribute named '{typeof(TAttribute).Name}': {string.Join(", ", PropertyNamesAndTypes.Select(p => ReportNameAndType(p)))}";
+            => $"If there is an attribute named '{typeof(TAttribute).NameWithGenericArguments()}': {string.Join(", ", PropertyNamesAndTypes.Select(p => ReportNameAndType(p)))}";
 
         private string ReportNameAndType(NameAndType p)
         {

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeWithImpliedPropertyRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeWithImpliedPropertyRule.cs
@@ -54,7 +54,7 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         public override string RuleDescription<TIRuleSet>()
-            => $"If there is an attribute named '{typeof(TAttribute).Name}', its first property, with type {typeof(TValue)}";
+            => $"If there is an attribute named '{typeof(TAttribute).NameWithGenericArguments()}', its first property, with type {typeof(TValue)}";
 
 
     }

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeWithPropertyRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeWithPropertyRule.cs
@@ -57,7 +57,7 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         public override string RuleDescription<TIRuleSet>()
-            => $"If there is an attribute named '{typeof(TAttribute).Name}', its '{PropertyName}' property, with type {typeof(TValue)}";
+            => $"If there is an attribute named '{typeof(TAttribute).NameWithGenericArguments()}', its '{PropertyName}' property, with type {typeof(TValue)}";
 
 
     }

--- a/System.CommandLine.GeneralAppModel/Rules/BooleanAttributeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/BooleanAttributeRule.cs
@@ -60,7 +60,7 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         public override string RuleDescription<TIRuleSet>()
-            => $"If there is an attribute named '{typeof(TAttribute).Name}', its '{PropertyName}' property, with type {typeof(bool)}";
+            => $"If there is an attribute named '{typeof(TAttribute).NameWithGenericArguments()}', its '{PropertyName}' property, with type {typeof(bool)}";
 
 
     }

--- a/System.CommandLine.GeneralAppModel/Rules/IsOfTypeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/IsOfTypeRule.cs
@@ -15,7 +15,7 @@ namespace System.CommandLine.GeneralAppModel
         public Type Type { get; }
 
         public override string RuleDescription<TIRuleSet>()
-            => $"Item is of type {Type}.";
+            => $"Item is of type {Type.NameWithGenericArguments()}.";
     }
 
     public class IsOfTypeRule<TType> : IsOfTypeRule, IRuleGetCandidates

--- a/System.CommandLine.GeneralAppModel/StandardRules.cs
+++ b/System.CommandLine.GeneralAppModel/StandardRules.cs
@@ -6,6 +6,14 @@ namespace System.CommandLine.GeneralAppModel
 {
     public static class StandardRules
     {
+        public static RuleSetDescriptorContext SetDescriptorContextRules(RuleSetDescriptorContext rules)
+        {
+            rules.DescriptionSourceRules
+                .Add(new AttributeWithImpliedPropertyRule<DescriptionSourceAttribute, Type>())
+                ;
+            return rules;
+        }
+
         public static RuleSetGetCandidatesRule SetCandidatesRules(RuleSetGetCandidatesRule rules)
         {
             rules.Rules
@@ -157,6 +165,5 @@ namespace System.CommandLine.GeneralAppModel
             
             return rules;
         }
-
     }
 }

--- a/System.CommandLine.GeneralAppModel/StandardStrategy.cs
+++ b/System.CommandLine.GeneralAppModel/StandardStrategy.cs
@@ -4,6 +4,7 @@
     {
         public static Strategy SetStandardRules(this Strategy strategy)
         {
+            StandardRules.SetDescriptorContextRules(strategy.DescriptorContextRules);
             StandardRules.SetSelectSymbolRules(strategy.SelectSymbolRules);
             StandardRules.SetCandidatesRules(strategy.GetCandidateRules);
             StandardRules.SetArgumentRules(strategy.ArgumentRules);

--- a/System.CommandLine.GeneralAppModel/Strategy.cs
+++ b/System.CommandLine.GeneralAppModel/Strategy.cs
@@ -11,6 +11,7 @@
         }
 
         public string Name { get; }
+        public RuleSetDescriptorContext DescriptorContextRules { get; } = new RuleSetDescriptorContext();
         public RuleSetGetCandidatesRule GetCandidateRules { get; } = new RuleSetGetCandidatesRule();
         public RuleSetSelectSymbols SelectSymbolRules { get; } = new RuleSetSelectSymbols();
         public RuleSetArgument ArgumentRules { get; } = new RuleSetArgument();
@@ -22,10 +23,10 @@
         {
             return $@"
 Strategy: {Name}
-   To classify symols:{ SelectSymbolRules.Report(2)}
-   For argument details:{ ArgumentRules.Report(2)}
-   For option details:{ OptionRules.Report(2)}
-   For command details:{ CommandRules.Report(2)}
+   Classify symbols as:{ SelectSymbolRules.Report(2)}
+   Argument details:{ ArgumentRules.Report(2)}
+   Option details:{ OptionRules.Report(2)}
+   Command details:{ CommandRules.Report(2)}
 ";
         }
 

--- a/System.CommandLine.GeneralAppModel/SymbolType.cs
+++ b/System.CommandLine.GeneralAppModel/SymbolType.cs
@@ -2,6 +2,7 @@
 {
     public enum SymbolType
     {
+        Unknown = 0,
         Command = 0b0001,
         Option = 0b0010,
         Argument = 0b0100,

--- a/System.CommandLine.GeneralAppModel/VerbosityLevels.cs
+++ b/System.CommandLine.GeneralAppModel/VerbosityLevels.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace System.CommandLine.ReflectionAppModel
+namespace System.CommandLine.GeneralAppModel 
 {
     public enum VerbosityLevel
     {


### PR DESCRIPTION
See #101

This does not complete 101 because there are naming issues resulting in options not yet reporting their description in help

Supports a set of method for determining descriptions. 

This is currently pretty simple, expecting a each description to appear only once.

It is route based to create a string for lookup. 

Multiple description sources are supported

How to find description sources is a rule, and logically then turning use of description sources on and off

DescriptionSourceRules is a new property on a new RuleSet. The new RuleSet is RuleSetDescriptorContext on Strategy which allows Strategy wide settings. I anticipate if we support configuration, this will be the location for it. An example of configuration or other Strategy wide issues would be the prefix on options. 