### PR TITLE
Updated names to triumverate fixing argument desc and added name morp…

### DIFF
--- a/ReflectionAppModel.Tests/DotnetCLI/DotnetModel.cs
+++ b/ReflectionAppModel.Tests/DotnetCLI/DotnetModel.cs
@@ -5,7 +5,7 @@ namespace System.CommandLine.ReflectionAppModel.DotnetCLI
     public class Dotnet
     {
         [Description("Install the tool for the current user.")]
-        [Aliases("--v")]
+        [Aliases("-v")]
         public VerbosityLevel verbosity { get; set; }
 
     }

--- a/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/MethodDescriptorMakerTests.cs
@@ -27,20 +27,22 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         #region Command tests
         [Theory]
-        [InlineData(full, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), "")]
-        [InlineData(full, typeof(MethodWithNameAttribute), constant.Name , "")]
-        [InlineData(full, typeof(MethodWithNameInCommandAttribute), constant.Name, "")]
-        [InlineData(full, typeof(MethodWithDescriptionAttribute), constant.TestMethodName, constant.Description)]
-        [InlineData(full, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, constant.Description)]
-        [InlineData(standard, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), "")]
-        [InlineData(standard, typeof(MethodWithNameInCommandAttribute), constant.Name, "")]
-        [InlineData(standard, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, constant.Description)]
-        public void NameAndDescriptionFromType(string useStrategy, Type typeToTest, string name, string description)
+        [InlineData(full, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), constant.KebabMethodString, "")]
+        [InlineData(full, typeof(MethodWithNameAttribute), constant.Name, nameof(MethodWithNameAttribute.Method), constant.KebabName, "")]
+        [InlineData(full, typeof(MethodWithNameInCommandAttribute), constant.Name, nameof(MethodWithNameInCommandAttribute.Method), constant.KebabName, "")]
+        [InlineData(full, typeof(MethodWithDescriptionAttribute), constant.TestMethodName, nameof(MethodWithDescriptionAttribute.Method), constant.KebabTestMethodName, constant.Description)]
+        [InlineData(full, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, nameof(MethodWithDescriptionInCommandAttribute.Method), constant.KebabTestMethodName, constant.Description)]
+        [InlineData(standard, typeof(MethodEmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), nameof(MethodEmptyMethod.EmptyMethod), constant.KebabMethodString, "")]
+        [InlineData(standard, typeof(MethodWithNameInCommandAttribute), constant.Name, nameof(MethodWithNameInCommandAttribute.Method), constant.KebabName, "")]
+        [InlineData(standard, typeof(MethodWithDescriptionInCommandAttribute), constant.TestMethodName, nameof(MethodWithDescriptionInCommandAttribute.Method), constant.KebabTestMethodName, constant.Description)]
+        public void MethodNameAndDescriptionFrom(string useStrategy, Type typeToTest, string name, string originalName, string commandLineName, string description)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy , method);
 
             descriptor.Should().HaveName(name)
+                    .And.HaveOriginalName(originalName)
+                    .And.HaveCommandLineName(commandLineName)
                     .And.HaveDescription(description);
         }
 
@@ -48,7 +50,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Theory]
         [InlineData(full, typeof(MethodWithOneAliasAttribute), constant.AliasAsStringSingle)]
         [InlineData(full, typeof(MethodWithThreeAliasesInOneAttribute), constant.AliasAsStringMultiple)]
-        public void AliasesFromType(string useStrategy, Type typeToTest, string aliasesAsString)
+        public void AliasesFromMethod(string useStrategy, Type typeToTest, string aliasesAsString)
         {
             var aliases = aliasesAsString is null
                           ? null
@@ -68,7 +70,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(full, typeof(MethodWithIsHiddenTrueAsImplied), true)]
         [InlineData(standard, typeof(MethodWithIsHiddenTrueInCommandAttribute), true)]
         [InlineData(standard, typeof(MethodWithIsHiddenFalseInCommandAttribute), false)]
-        public void CommandIsHiddenFromType(string useStrategy, Type typeToTest, bool isHidden)
+        public void CommandIsHiddenFromMethod(string useStrategy, Type typeToTest, bool isHidden)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
@@ -84,7 +86,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(full, typeof(MethodWithTreatUnmatchedTokensAsErrorsTrueAsImplied), true)]
         [InlineData(standard, typeof(MethodWithTreatUnmatchedTokensAsErrorsTrueInCommandAttribute), true)]
         [InlineData(standard, typeof(MethodWithTreatUnmatchedTokensAsErrorsFalseInCommandAttribute), false)]
-        public void CommandTreatUnmatchedTokensAsErrorsFromType(string useStrategy, Type typeToTest, bool treatUnmatchedTokensAsErrors)
+        public void CommandTreatUnmatchedTokensAsErrorsFromMethod(string useStrategy, Type typeToTest, bool treatUnmatchedTokensAsErrors)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
@@ -128,21 +130,24 @@ namespace System.CommandLine.GeneralAppModel.Tests
         #region Option tests
 
         [Theory]
-        [InlineData(full, typeof(ParameterOptionWithName), constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameAttribute), constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), constant.Name, "")]
-        [InlineData(full, typeof(ParameterOptionWithDescriptionAttribute), constant.ParameterOptionName, constant.Description)]
-        [InlineData(full, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.Description)]
-        [InlineData(standard, typeof(ParameterOptionWithName), constant.Name, "")]
-        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute),  constant.Name, "")]
-        [InlineData(standard, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.Description)]
-        public void OptionNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string description)
+        [InlineData(full, typeof(ParameterOptionWithName), constant.Name, constant.Name, constant.KebabName, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameAttribute), constant.Name, constant.ParameterOptionName, constant.KebabName, "")]
+        [InlineData(full, typeof(ParameterOptionWithNameInOptionAttribute), constant.Name, constant.ParameterOptionName, constant.KebabName, "")]
+        [InlineData(full, typeof(ParameterOptionWithDescriptionAttribute), constant.ParameterOptionName, constant.ParameterOptionName, constant.KebabParameterOptionName, constant.Description)]
+        [InlineData(full, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.ParameterOptionName, constant.KebabParameterOptionName, constant.Description)]
+        [InlineData(standard, typeof(ParameterOptionWithName), constant.Name, constant.Name, constant.KebabName, "")]
+        [InlineData(standard, typeof(ParameterOptionWithNameInOptionAttribute),  constant.Name, constant.ParameterOptionName, constant.KebabName, "")]
+        [InlineData(standard, typeof(ParameterOptionWithDescriptionInOptionAttribute), constant.ParameterOptionName, constant.ParameterOptionName, constant.KebabParameterOptionName, constant.Description)]
+        public void OptionNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string originalName, string commandLineName, string description)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
+            commandLineName = "--" + commandLineName;
 
             descriptor.Options.First()
                     .Should().HaveName(name)
+                    .And.HaveOriginalName(originalName)
+                    .And.HaveCommandLineName(commandLineName)
                     .And.HaveDescription(description);
         }
 
@@ -231,21 +236,23 @@ namespace System.CommandLine.GeneralAppModel.Tests
         #region Argument Tests
 
         [Theory]
-        [InlineData(full, typeof(ParameterArgumentWithName), constant.Name, "")]
-        [InlineData(full, typeof(ParameterArgumentWithNameAttribute), constant.Name, "")]
-        [InlineData(full, typeof(ParameterArgumentWithNameInArgumentAttribute), constant.Name, "")]
-        [InlineData(full, typeof(ParameterArgumentWithDescriptionAttribute), constant.ParameterArgName, constant.Description)]
-        [InlineData(full, typeof(ParameterArgumentWithDescriptionInArgumentAttribute), constant.ParameterArgName, constant.Description)]
-        [InlineData(standard, typeof(ParameterArgumentWithName), constant.Name, "")]
-        [InlineData(standard, typeof(ParameterArgumentWithNameInArgumentAttribute), constant.Name, "")]
-        [InlineData(standard, typeof(ParameterArgumentWithDescriptionInArgumentAttribute), constant.ParameterArgName, constant.Description)]
-        public void ArgumentNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string description)
+        [InlineData(full, typeof(ParameterArgumentWithName), constant.Name, constant.Name + "Arg", constant.Name, "")]
+        [InlineData(full, typeof(ParameterArgumentWithNameAttribute), constant.Name, "ParamArg", constant.Name, "")]
+        [InlineData(full, typeof(ParameterArgumentWithNameInArgumentAttribute), constant.Name, "ParamArg", constant.Name, "")]
+        [InlineData(full, typeof(ParameterArgumentWithDescriptionAttribute), constant.ParameterArgName, constant.ParameterArgName + "Arg", constant.ParameterArgName, constant.Description)]
+        [InlineData(full, typeof(ParameterArgumentWithDescriptionInArgumentAttribute), constant.ParameterArgName, constant.ParameterArgName + "Arg", constant.ParameterArgName, constant.Description)]
+        [InlineData(standard, typeof(ParameterArgumentWithName), constant.Name, constant.Name + "Arg", constant.Name, "")]
+        [InlineData(standard, typeof(ParameterArgumentWithNameInArgumentAttribute), constant.Name, "ParamArg", constant.Name, "")]
+        [InlineData(standard, typeof(ParameterArgumentWithDescriptionInArgumentAttribute), constant.ParameterArgName, constant.ParameterArgName + "Arg", constant.ParameterArgName, constant.Description)]
+        public void ArgumentNameAndDescriptionFromParameter(string useStrategy, Type typeToTest, string name, string originalName, string commandLineName, string description)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
 
             descriptor.Arguments.First()
                     .Should().HaveName(name)
+                    .And.HaveOriginalName(originalName)
+                    .And.HaveCommandLineName(commandLineName)
                     .And.HaveDescription(description);
         }
 
@@ -306,7 +313,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(full, typeof(ParameterArgumentWithRequiredTrueAsImplied), true)]
         [InlineData(standard, typeof(ParameterArgumentWithRequiredTrueInArgumentAttribute), true)]
         [InlineData(standard, typeof(ParameterArgumentWithRequiredFalseInArgumentAttribute), false)]
-        public void ArgumentRequiredFromType(string useStrategy, Type typeToTest, bool isHidden)
+        public void ArgumentRequiredFromMethod(string useStrategy, Type typeToTest, bool isHidden)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
@@ -322,7 +329,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(standard, typeof(ParameterArgumentWithNoArity), false, 0, int.MaxValue)]
         [InlineData(standard, typeof(ParameterArgumentWithArityLowerBoundOnly), true, 2, int.MaxValue)]
         [InlineData(standard, typeof(ParameterArgumentWithArityBothBounds), true, 2, 3)]
-        public void ArgumentArityFromType(string useStrategy, Type typeToTest, bool isSet, int minCount, int maxCount)
+        public void ArgumentArityFromMethod(string useStrategy, Type typeToTest, bool isSet, int minCount, int maxCount)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);
@@ -338,7 +345,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData(standard, typeof(ParameterArgumentWithNoDefaultValue), false, null)]
         [InlineData(standard, typeof(ParameterArgumentWithStringDefaultValue), true, constant.DefaultValueString)]
         [InlineData(standard, typeof(ParameterArgumentWithIntegerDefaultValue), true, constant.DefaultValueInt)]
-        public void ArgumentDefaultValuesFromType(string useStrategy, Type typeToTest, bool isSet, object value)
+        public void ArgumentDefaultValuesFromMethod(string useStrategy, Type typeToTest, bool isSet, object value)
         {
             var method = typeToTest.GetMethods().First();
             var descriptor = ReflectionDescriptorMaker.RootCommandDescriptor(useStrategy == full ? fullStrategy : standardStrategy, method);

--- a/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
+++ b/ReflectionAppModel.Tests/TypeDescriptorMakerTests.cs
@@ -39,6 +39,11 @@ namespace System.CommandLine.GeneralAppModel.Tests
         internal const string ParameterOptionName = "Param";
         internal const string ParameterArgName = "Param";
 
+        internal const string KebabMethodString = "empty-method";
+        internal const string KebabName = "george";
+        internal const string KebabTestMethodName = "method";
+        internal const string KebabParameterOptionName = "param";
+
         private readonly Strategy fullStrategy;
         private readonly Strategy standardStrategy;
         private const string full = "Full";

--- a/Samples/RuleExampleNamedAttr.Tests/ReportingTests.cs
+++ b/Samples/RuleExampleNamedAttr.Tests/ReportingTests.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         {
             var rule = new IdentityRule<string>();
             var actual = rule.RuleDescription<IRuleGetValues<string>>();
-            var expected = "The identity, usually the name.";
+            var expected = "has not been matched, use the identity which is usually the Name";
 
             actual.Should().Be(expected);
         }
@@ -39,7 +39,7 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData("Abc", @"the name ends with 'Abc'")]
+        [InlineData("Abc", @"with a Name that ends with 'Abc'")]
         public void ReportForNameRuleForGetItemsIsCorrect(string compareTo, string expected)
         {
             var rule = new NameEndsWithRule(compareTo);
@@ -49,7 +49,7 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData("Abc", @"If name ends with 'Abc', remove 'Abc'")]
+        [InlineData("Abc", @"with a Name that ends with 'Abc'")]
         public void ReportForNameRuleForGetValueIsCorrect(string compareTo, string expected)
         {
             var rule = new NameEndsWithRule(compareTo);
@@ -84,12 +84,12 @@ namespace System.CommandLine.NamedAttributeRules.Tests
             var rule = new RemainingSymbolRule(SymbolType.Argument);
             var actual = rule.RuleDescription<IRuleGetValue<string>>();
 
-            actual.Should().Be("not already matched");
+            actual.Should().Be("that is not already matched");
         }
 
         [Theory]
-        [InlineData(StringContentsRule.StringPosition.BeginsWith, "Abc", @"the string begins with 'Abc'")]
-        public void ReportForStringContentxForGetItemsIsCorrect(StringContentsRule.StringPosition position,
+        [InlineData(StringPosition.BeginsWith, "Abc", @"with a string that begins with 'Abc'")]
+        public void ReportForStringContentxForGetItemsIsCorrect(StringPosition position,
             string compareTo, string expected)
         {
             var rule = new StringContentsRule(position, compareTo);
@@ -99,8 +99,8 @@ namespace System.CommandLine.NamedAttributeRules.Tests
         }
 
         [Theory]
-        [InlineData(StringContentsRule.StringPosition.BeginsWith, "Abc", @"If string begins with 'Abc', remove 'Abc'")]
-        public void ReportForStringContentsForGetValueIsCorrect(StringContentsRule.StringPosition position,
+        [InlineData(StringPosition.BeginsWith, "Abc", @"with a string that begins with 'Abc'")]
+        public void ReportForStringContentsForGetValueIsCorrect(StringPosition position,
             string compareTo, string expected)
         {
             var rule = new StringContentsRule(position, compareTo);

--- a/System.CommandLine.GeneralAppModel.Tests/Assertions/SymbolDescriptorAssertions.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/Assertions/SymbolDescriptorAssertions.cs
@@ -33,16 +33,35 @@ namespace System.CommandLine.GeneralAppModel.Tests
         {
             Execute.Assertion
                      .ForCondition(Subject.Name == expected)
-                     .FailWith(Utils.DisplayEqualsFailure(SymbolType.Command, "Name", expected, Subject.Name));
+                     .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType , "Name", expected, Subject.Name));
 
             return new AndConstraint<TAssert>((TAssert)this);
         }
+
+        public AndConstraint<TAssert> HaveOriginalName(string expected)
+        {
+            Execute.Assertion
+                     .ForCondition(Subject.OriginalName == expected)
+                     .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType, "OriginalName", expected, Subject.OriginalName));
+
+            return new AndConstraint<TAssert>((TAssert)this);
+        }
+
+        public AndConstraint<TAssert> HaveCommandLineName(string expected)
+        {
+            Execute.Assertion
+                     .ForCondition(Subject.CommandLineName == expected)
+                     .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType, "CommandLineName", expected, Subject.CommandLineName));
+
+            return new AndConstraint<TAssert>((TAssert)this);
+        }
+
 
         public AndConstraint<TAssert> HaveDescription(string expected)
         {
             Execute.Assertion
                      .ForCondition(Subject.Description == expected)
-                     .FailWith(Utils.DisplayEqualsFailure(SymbolType.Command, "Description", expected, Subject.Description));
+                     .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType, "Description", expected, Subject.Description));
 
             return new AndConstraint<TAssert>((TAssert)this);
         }
@@ -51,7 +70,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         {
             Execute.Assertion
                      .ForCondition(Subject.IsHidden == expected)
-                     .FailWith(Utils.DisplayEqualsFailure(SymbolType.Command, "IsHidden", expected, Subject.IsHidden));
+                     .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType, "IsHidden", expected, Subject.IsHidden));
 
             return new AndConstraint<TAssert>((TAssert)this);
         }
@@ -80,7 +99,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             }
             Execute.Assertion
                              .ForCondition(expectedAliases == actualAliases)
-                             .FailWith(Utils.DisplayEqualsFailure(SymbolType.Command, "Aliases", expected, Subject.Aliases));
+                             .FailWith(Utils.DisplayEqualsFailure(Subject.SymbolType, "Aliases", expected, Subject.Aliases));
 
             return new AndConstraint<TAssert>((TAssert)this);
         }

--- a/System.CommandLine.GeneralAppModel.Tests/DescriptorValidationTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/DescriptorValidationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine.GeneralAppModel.Descriptors;
 using System.CommandLine.GeneralAppModel.Tests.Maker;
+using System.Linq;
 using System.Text;
 using Xunit;
 
@@ -17,8 +18,10 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData("\t")]
         public void DescriptorValidationThrowsIfSubCommandNameNullOrWhitespace(string? name)
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
-            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, null)
+#pragma warning disable CS8604 // This is part of the test, do not fix
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, name, raw: null);
+            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, name, raw: null)
+#pragma warning restore CS8604 // Possible null reference argument.
             { Name = name });
 
             var ex = Assert.Throws<InvalidOperationException>(() => CommandMaker.MakeRootCommand(descriptor));
@@ -35,8 +38,10 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData("\t")]
         public void DescriptorValidationThrowsIfOptionNameNullOrWhitespace(string? name)
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
-            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, null)
+#pragma warning disable CS8604 // This is part of the test, do not fix
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, name, raw: null);
+            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, name, null)
+#pragma warning restore CS8604 // Possible null reference argument.
             { Name = name });
 
             var ex = Assert.Throws<InvalidOperationException>(() => CommandMaker.MakeRootCommand(descriptor));
@@ -53,7 +58,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData("\t")]
         public void DescriptorValidationDoesNotThrowForEmptyRootName(string? name)
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null)
+#pragma warning disable CS8604 // This is part of the test, do not fix
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, name, raw: null)
+#pragma warning restore CS8604 // Possible null reference argument.
             { Name = name };
 
             var root = CommandMaker.MakeRootCommand(descriptor);
@@ -65,8 +72,11 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData("george")]
         public void DescriptorValidationDoesNotThrowForNotEmptySubCommandName(string? name)
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandBasicsTestData));
-            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandBasicsTestData))
+#pragma warning disable CS8604 // This is part of the test, do not fix
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, name, raw: typeof(CommandBasicsTestData));
+            descriptor.CommandLineName = name;
+            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, name, raw: typeof(CommandBasicsTestData))
+#pragma warning restore CS8604 // Possible null reference argument.
             {
                 Name = name
             });
@@ -80,11 +90,14 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [InlineData("george")]
         public void DescriptorValidationDoesNotThrowForNotEmptyOptionName(string? name)
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
-            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, null)
+#pragma warning disable CS8604 // This is part of the test, do not fix
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, name, raw: null);
+            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, name, null)
+#pragma warning disable CS8604 // This is part of the test, do not fix
             {
                 Name = name
             });
+            descriptor.Options.First().CommandLineName  = name;
 
             var root = CommandMaker.MakeRootCommand(descriptor);
             root.Should().NotBeNull(); // Just be sure there is no exception
@@ -93,10 +106,10 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Fact]
         public void DescriptorValidationThrowsIfArgumentTypeIsNull()
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, "", raw: null);
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             // DO NOT FIX THE NULLABLE IN THE NEXT LINE
-            descriptor.Arguments.Add(new ArgumentDescriptor(null, SymbolDescriptor.Empty, null));
+            descriptor.Arguments.Add(new ArgumentDescriptor(null, SymbolDescriptor.Empty, "", null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             var ex = Assert.Throws<InvalidOperationException>(() => CommandMaker.MakeRootCommand(descriptor));
@@ -109,14 +122,14 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Fact]
         public void DescriptorValidationCanReportMultipleIssues()
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
-            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, null)
-            { Name = null });
-            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, null)
-            { Name = null });
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null, raw: null);
+            descriptor.Options.Add(new OptionDescriptor(SymbolDescriptor.Empty, null, null)
+            { Name = null });
+            descriptor.SubCommands.Add(new CommandDescriptor(SymbolDescriptor.Empty, null, raw: null)
+            { Name = null });
             // DO NOT FIX THE NULLABLE IN THE NEXT LINE
-            descriptor.Arguments.Add(new ArgumentDescriptor(null, SymbolDescriptor.Empty, null));
+            descriptor.Arguments.Add(new ArgumentDescriptor(null, SymbolDescriptor.Empty, null, null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             var ex = Assert.Throws<InvalidOperationException>(() => CommandMaker.MakeRootCommand(descriptor));
@@ -132,9 +145,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
         [Fact]
         public void DescriptorValidationThrowsIfALlowedValuesOfWrongType()
         {
-            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, null);
+            var descriptor = new CommandDescriptor(SymbolDescriptor.Empty, "", raw: null);
             // ArgumentType is int, value is string
-            var argumentDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(int)), SymbolDescriptor.Empty, null);
+            var argumentDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(int)), SymbolDescriptor.Empty, "", null);
             argumentDescriptor.AllowedValues.Add("Fred");
             descriptor.Arguments.Add(argumentDescriptor);
 

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/ArgumentTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/ArgumentTestData.cs
@@ -9,17 +9,19 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     public class ArgumentBasicsTestData : MakerCommandTestData
     {
         public ArgumentBasicsTestData(string name, string description, string[] aliases, bool isHidden, Type argumentType)
-            : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(ArgumentBasicsTestData)) { Name = DummyCommandName })
+            : base(new CommandDescriptor(SymbolDescriptor.Empty, name, raw: typeof(ArgumentBasicsTestData)) { Name = DummyCommandName })
         {
             Descriptor.Arguments.Add(
-                new ArgumentDescriptor(new ArgTypeInfo ( argumentType), SymbolDescriptor.Empty, DummyRaw)
+                new ArgumentDescriptor(new ArgTypeInfo(argumentType), SymbolDescriptor.Empty, name, DummyRaw)
                 {
                     Name = name,
+                    CommandLineName = name,
                     Description = description,
                     Aliases = aliases,
                     IsHidden = isHidden,
                 });
             Name = name;
+            CommandLineName = name;
             Description = description;
             Aliases = aliases;
             IsHidden = isHidden;
@@ -27,6 +29,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         }
 
         public string Name { get; }
+        public string CommandLineName { get; }
         public string Description { get; }
         public string[] Aliases { get; }
         public bool IsHidden { get; }
@@ -48,9 +51,9 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     public class ArgumentArityTestData : MakerCommandTestData
     {
         public ArgumentArityTestData(bool isSet, int? minValue = null, int? maxValue = null)
-            : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(ArgumentArityTestData)) { Name = DummyCommandName })
+            : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(ArgumentArityTestData)) { Name = DummyCommandName })
         {
-            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo (  typeof(string)), SymbolDescriptor.Empty, DummyRaw)
+            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, DummyArgumentName, DummyRaw)
             {
                 Name = DummyArgumentName,
             };
@@ -87,16 +90,16 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     public class ArgumentDefaultValueTestData : MakerCommandTestData
     {
         public ArgumentDefaultValueTestData(bool isSet, object defaultValue)
-            : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(ArgumentDefaultValueTestData)) { Name = DummyCommandName })
+            : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(ArgumentDefaultValueTestData)) { Name = DummyCommandName })
         {
-            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, DummyRaw)
+            var argDescriptor = new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, DummyArgumentName, DummyRaw)
             {
                 Name = DummyArgumentName,
             };
 
             if (isSet)
             {
-                argDescriptor.DefaultValue  = new DefaultValueDescriptor(defaultValue)
+                argDescriptor.DefaultValue = new DefaultValueDescriptor(defaultValue)
                 { };
             }
             Descriptor.Arguments.Add(argDescriptor);
@@ -112,7 +115,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
             var actual = command.Arguments.FirstOrDefault();
 
             using var scope = new AssertionScope();
-            actual.Should().HaveDefaultValue(IsSet, DefaultValue );
+            actual.Should().HaveDefaultValue(IsSet, DefaultValue);
         }
     }
 

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/CommandTestData.cs
@@ -12,7 +12,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     {
         public CommandBasicsTestData(string name, string description, string[] aliases, bool isHidden, bool treatUnmatchedTokensAsErrors)
             : base(
-                      new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandBasicsTestData))
+                      new CommandDescriptor(SymbolDescriptor.Empty, name, raw: typeof(CommandBasicsTestData))
                       {
                           Name = name,
                           Description = description,
@@ -55,10 +55,10 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     {
         // Option and ArgumentTestData of necessity test adding a single option and argument
         public CommandOneSubCommandTestData(string subCommandName)
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandOneSubCommandTestData)) { Name = DummyCommandName })
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(CommandOneSubCommandTestData)) { Name = DummyCommandName })
         {
             Descriptor.SubCommands.Add(
-                new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandDescriptor))
+                new CommandDescriptor(SymbolDescriptor.Empty, subCommandName, raw: typeof(CommandDescriptor))
                 {
                     Name = subCommandName
                 });
@@ -81,15 +81,15 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     {
         // Option and ArgumentTestData of necessity test adding a single option and argument
         public CommandTwoSubCommandsTestData(string subCommandName1, string subCommandName2)
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandTwoSubCommandsTestData)) { Name = DummyCommandName })
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(CommandTwoSubCommandsTestData)) { Name = DummyCommandName })
         {
             Descriptor.SubCommands.Add(
-                new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandHandlerRunsTestData))
+                new CommandDescriptor(SymbolDescriptor.Empty, subCommandName1, raw: typeof(CommandHandlerRunsTestData))
                 {
                     Name = subCommandName1
                 });
             Descriptor.SubCommands.Add(
-                new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandHandlerRunsTestData))
+                new CommandDescriptor(SymbolDescriptor.Empty, subCommandName2, raw: typeof(CommandHandlerRunsTestData))
                 {
                     Name = subCommandName2
                 });
@@ -119,13 +119,17 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         private static string checkValue = "";
         // Option and ArgumentTestData of necessity test adding a single option and argument
         public CommandHandlerRunsTestData()
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandHandlerRunsTestData).GetMethod("Run")!)
-              { Name = DummyCommandName })
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, "Run", raw: typeof(CommandHandlerRunsTestData).GetMethod("Run")!)
+              {
+                  Name = DummyCommandName,
+                  CommandLineName = KebabDummyCommandName
+              })
         {
             Descriptor.Arguments.Add(
-                    new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, Utils.EmptyRawForTest)
+                    new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, "HelloTo", Utils.EmptyRawForTest)
                     {
-                        Name = "HelloTo"
+                        Name = "HelloTo",
+                        CommandLineName = "HelloTo"
                     }
                 );
         }
@@ -158,9 +162,10 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         private static string checkValue = "";
         // Option and ArgumentTestData of necessity test adding a single option and argument
         public CommandInvokeMethodTestData()
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandInvokeMethodTestData))
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(CommandInvokeMethodTestData))
               {
                   Name = DummyCommandName,
+                  CommandLineName = KebabDummyCommandName,
                   InvokeMethod = new InvokeMethodInfo(typeof(CommandInvokeMethodTestData).GetMethod("Invoke")!, "Invoke", 0)
               })
         { }
@@ -194,22 +199,25 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         private static string checkValue = "";
         // Option and ArgumentTestData of necessity test adding a single option and argument
         public CommandInvokeMethodMultipleParametersTestData()
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(CommandInvokeMethodMultipleParametersTestData))
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, DummyCommandName, raw: typeof(CommandInvokeMethodMultipleParametersTestData))
               {
                   Name = DummyCommandName,
+                  CommandLineName = KebabDummyCommandName,
                   InvokeMethod = new InvokeMethodInfo(typeof(CommandInvokeMethodMultipleParametersTestData).GetMethod("Invoke")!, "Invoke", 0)
               })
         {
             Descriptor.Arguments.Add(
-                  new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, Utils.EmptyRawForTest)
+                  new ArgumentDescriptor(new ArgTypeInfo(typeof(string)), SymbolDescriptor.Empty, "To", Utils.EmptyRawForTest)
                   {
-                      Name = "To"
+                      Name = "To",
+                      CommandLineName = "to"
                   }
               );
             Descriptor.Options.Add(
-                 new OptionDescriptor( SymbolDescriptor.Empty, Utils.EmptyRawForTest)
+                 new OptionDescriptor(SymbolDescriptor.Empty, "AllCaps", Utils.EmptyRawForTest)
                  {
-                     Name = "AllCaps"
+                     Name = "AllCaps",
+                     CommandLineName = "--all-caps"
                  }
              );
         }

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/MakerCommandTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/MakerCommandTestData.cs
@@ -8,6 +8,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         protected const string DummyArgumentName = "DummyArgumentName";
         protected const string DummyCommandName = "DummyCommandName";
         protected const string DummyRaw = "Explicit Descriptor";
+        protected const string KebabDummyCommandName = "dummy-command-name";
 
         public MakerCommandTestData(CommandDescriptor descriptor)
         {

--- a/System.CommandLine.GeneralAppModel.Tests/MakerTestData/OptionTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/MakerTestData/OptionTestData.cs
@@ -9,12 +9,17 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
     public class OptionBasicsTestData : MakerCommandTestData
     {
         public OptionBasicsTestData(string name, string description, string[] aliases, bool isHidden, bool required)
-              : base(new CommandDescriptor(SymbolDescriptor.Empty, typeof(OptionBasicsTestData)) { Name = DummyCommandName })
+              : base(new CommandDescriptor(SymbolDescriptor.Empty, name, raw: typeof(OptionBasicsTestData))
+              {
+                  Name = DummyCommandName,
+                  CommandLineName = KebabDummyCommandName
+              })
         {
             Descriptor.Options.Add(
-                        new OptionDescriptor(SymbolDescriptor.Empty, Utils.EmptyRawForTest)
+                        new OptionDescriptor(SymbolDescriptor.Empty, name, Utils.EmptyRawForTest)
                         {
                             Name = name,
+                            CommandLineName = name,
                             Description = description,
                             Aliases = aliases,
                             IsHidden = isHidden,
@@ -34,7 +39,7 @@ namespace System.CommandLine.GeneralAppModel.Tests.Maker
         public bool IsHidden { get; }
         public bool Required { get; }
 
-        public override void Check(Command  command)
+        public override void Check(Command command)
         {
             var actual = command.Options.FirstOrDefault();
             var name = Name.ToKebabCase().ToLowerInvariant();

--- a/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/ReportingTests.cs
@@ -28,7 +28,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         {
             var rule = new IdentityRule<string>();
             var actual = rule.RuleDescription<IRuleGetValues<string>>();
-            var expected = "The identity, usually the name.";
+            var expected = "has not been matched, use the identity which is usually the Name";
 
             actual.Should().Be(expected);
         }
@@ -39,7 +39,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         }
 
         [Theory]
-        [InlineData("Abc", @"the name ends with 'Abc'")]
+        [InlineData("Abc", @"with a Name that ends with 'Abc'")]
         public void ReportForNameRuleForGetItemsIsCorrect(string compareTo, string expected)
         {
             var rule = new NameEndsWithRule(compareTo);
@@ -49,7 +49,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
         }
 
         [Theory]
-        [InlineData("Abc", @"If name ends with 'Abc', remove 'Abc'")]
+        [InlineData("Abc", @"with a Name that ends with 'Abc'")]
         public void ReportForNameRuleForGetValueIsCorrect(string compareTo, string expected)
         {
             var rule = new NameEndsWithRule(compareTo);
@@ -64,7 +64,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var rule = new AttributeRule<DescriptionAttribute>();
             var actual = rule.RuleDescription<IRuleGetValue<string>>();
 
-            actual.Should().Be(@"If there is an attribute named 'DescriptionAttribute'");
+            actual.Should().Be(@"with an attribute named 'Description'");
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var rule = new AttributeWithPropertyValueRule<ArgumentAttribute, string>( "Name");
             var actual = rule.RuleDescription<IRuleGetValue<string>>();
 
-            actual.Should().Be("If there is an attribute named 'ArgumentAttribute', its 'Name' property, with type System.String");
+            actual.Should().Be("has an attribute named 'Argument', use the 'Name' property if present");
         }
 
         [Fact()]
@@ -82,12 +82,12 @@ namespace System.CommandLine.GeneralAppModel.Tests
             var rule = new RemainingSymbolRule(SymbolType.Argument);
             var actual = rule.RuleDescription<IRuleGetValue<string>>();
 
-            actual.Should().Be("not already matched");
+            actual.Should().Be("that is not already matched");
         }
 
         [Theory]
-        [InlineData(StringContentsRule.StringPosition.BeginsWith, "Abc", @"the string begins with 'Abc'")]
-        public void ReportForStringContentxForGetItemsIsCorrect(StringContentsRule.StringPosition position,
+        [InlineData(StringPosition.BeginsWith, "Abc", @"with a string that begins with 'Abc'")]
+        public void ReportForStringContentxForGetItemsIsCorrect(StringPosition position,
             string compareTo, string expected)
         {
             var rule = new StringContentsRule(position, compareTo);
@@ -97,8 +97,8 @@ namespace System.CommandLine.GeneralAppModel.Tests
         }
 
         [Theory]
-        [InlineData(StringContentsRule.StringPosition.BeginsWith, "Abc", @"If string begins with 'Abc', remove 'Abc'")]
-        public void ReportForStringContentsForGetValueIsCorrect(StringContentsRule.StringPosition position,
+        [InlineData(StringPosition.BeginsWith, "Abc", @"with a string that begins with 'Abc'")]
+        public void ReportForStringContentsForGetValueIsCorrect(StringPosition position,
             string compareTo, string expected)
         {
             var rule = new StringContentsRule(position, compareTo);

--- a/System.CommandLine.GeneralAppModel.Tests/StrategyCreationTests.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/StrategyCreationTests.cs
@@ -37,11 +37,11 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
             rules.Should().HaveCount(7);
             rules[0].CheckAttributeRule<CommandAttribute>(SymbolType.Command);
-            rules[1].CheckNamePatternRule(SymbolType.Command, StringContentsRule.StringPosition.EndsWith, "Command");
+            rules[1].CheckNamePatternRule(SymbolType.Command, StringPosition.EndsWith, "Command");
             rules[2].CheckIsOfTypeRule(SymbolType.Command, typeof(Type));
             rules[3].CheckAttributeRule<ArgumentAttribute>(SymbolType.Argument);
-            rules[4].CheckNamePatternRule(SymbolType.Argument, StringContentsRule.StringPosition.EndsWith, "Argument");
-            rules[5].CheckNamePatternRule(SymbolType.Argument, StringContentsRule.StringPosition.EndsWith, "Arg");
+            rules[4].CheckNamePatternRule(SymbolType.Argument, StringPosition.EndsWith, "Argument");
+            rules[5].CheckNamePatternRule(SymbolType.Argument, StringPosition.EndsWith, "Arg");
             rules[6].CheckRule<RemainingSymbolRule>(SymbolType.Option);
 
         }
@@ -70,8 +70,8 @@ namespace System.CommandLine.GeneralAppModel.Tests
                     {
                         new NamedAttributeWithPropertyTestData("Name","Name", typeof(string)),
                         new NamedAttributeWithPropertyTestData("Argument","Name", typeof(string)),
-                        new NamePatternTestData(StringContentsRule.StringPosition.EndsWith, "Arg"),
-                        new NamePatternTestData(StringContentsRule.StringPosition.EndsWith, "Argument"),
+                        new NamePatternTestData(StringPosition.EndsWith, "Arg"),
+                        new NamePatternTestData(StringPosition.EndsWith, "Argument"),
                         new IdentityRuleTestData(typeof(string))
                     }
             });

--- a/System.CommandLine.GeneralAppModel.Tests/TestSupport/RuleGroupTestData.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/TestSupport/RuleGroupTestData.cs
@@ -42,13 +42,13 @@ namespace System.CommandLine.GeneralAppModel.Tests
     {
         public string CompareTo { get; set; }
 
-        public NamePatternTestData(StringContentsRule.StringPosition position, string compareTo)
+        public NamePatternTestData(StringPosition position, string compareTo)
         {
             CompareTo = compareTo;
             Position = position;
         }
 
-        public StringContentsRule.StringPosition Position { get; set; }
+        public StringPosition Position { get; set; }
     }
 
     public class IdentityRuleTestData : RuleBaseTestData

--- a/System.CommandLine.GeneralAppModel.Tests/TestSupport/TestDataExtensions.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/TestSupport/TestDataExtensions.cs
@@ -15,7 +15,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         public static OptionDescriptor CreateDescriptor(this OptionTestData data, ISymbolDescriptor parentSymbolDescriptor)
         {
-            var option = new OptionDescriptor(SymbolDescriptor.Empty, data.Raw)
+#pragma warning disable CS8604 // Possible null reference argument.
+            var option = new OptionDescriptor(SymbolDescriptor.Empty, data.Name, data.Raw)
+#pragma warning restore CS8604 // Possible null reference argument.
             {
                 Name = data.Name,
                 Description = data.Description,
@@ -34,7 +36,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
         public static ArgumentDescriptor CreateDescriptor(this ArgumentTestData data, ISymbolDescriptor parentSymbolDescriptor)
         {
             var _ = data.ArgumentType ?? throw new InvalidOperationException("ArgumentType cannot be null");
-            var arg = new ArgumentDescriptor(new ArgTypeInfo(data.ArgumentType), parentSymbolDescriptor, data.Raw)
+#pragma warning disable CS8604 // Possible null reference argument.
+            var arg = new ArgumentDescriptor(new ArgTypeInfo(data.ArgumentType), parentSymbolDescriptor, data.Name, data.Raw)
+#pragma warning restore CS8604 // Possible null reference argument.
             {
                 Name = data.Name,
                 Description = data.Description,
@@ -58,7 +62,9 @@ namespace System.CommandLine.GeneralAppModel.Tests
 
         public static CommandDescriptor CreateDescriptor(this CommandTestData data, ISymbolDescriptor parentSymbolDescriptor)
         {
-            var command = new CommandDescriptor(parentSymbolDescriptor, data.Raw)
+#pragma warning disable CS8604 // Possible null reference argument.
+            var command = new CommandDescriptor(parentSymbolDescriptor, data.Name, raw: data.Raw)
+#pragma warning restore CS8604 // Possible null reference argument.
             {
                 Name = data.Name,
                 Description = data.Description,

--- a/System.CommandLine.GeneralAppModel.Tests/Utils.cs
+++ b/System.CommandLine.GeneralAppModel.Tests/Utils.cs
@@ -36,7 +36,7 @@ namespace System.CommandLine.GeneralAppModel.Tests
             rule.SymbolType.Should().IncludeSymbolType(symbolType);
         }
 
-        public static void CheckNamePatternRule(this IRule rule, SymbolType symbolType, StringContentsRule.StringPosition position, string compareTo)
+        public static void CheckNamePatternRule(this IRule rule, SymbolType symbolType, StringPosition position, string compareTo)
         {
             rule.CheckRule<NameEndsWithRule>(symbolType);
             var typeRule = rule as NameEndsWithRule;

--- a/System.CommandLine.GeneralAppModel/Candidate.cs
+++ b/System.CommandLine.GeneralAppModel/Candidate.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace System.CommandLine.GeneralAppModel
 {
@@ -12,6 +13,22 @@ namespace System.CommandLine.GeneralAppModel
         }
 
         public object Item { get; }
+
+        public string Identity
+        {
+            get
+            {
+                var wrapper = traits
+                        .OfType<IdentityWrapper>()
+                        .FirstOrDefault();
+                return wrapper switch
+                {
+                    null => string.Empty,
+                    IdentityWrapper<string> w => w.Value,
+                    _ => (wrapper.ValueAsObject ?? string.Empty).ToString()
+                };
+            }
+        }
 
         public IEnumerable<object> Traits => traits;
 

--- a/System.CommandLine.GeneralAppModel/CommandMaker.cs
+++ b/System.CommandLine.GeneralAppModel/CommandMaker.cs
@@ -21,8 +21,9 @@ namespace System.CommandLine.GeneralAppModel
         public static Command MakeCommand(CommandDescriptor descriptor)
         {
             var _ = descriptor.Name ?? throw new InvalidOperationException("The name for a non-root command cannot be null");
+            var commandLineName = descriptor.CommandLineName ?? descriptor.Name;
 
-            return MakeCommandInternal(new Command(descriptor.Name.ToKebabCase()), descriptor);
+            return MakeCommandInternal(new Command(commandLineName), descriptor);
         }
 
         public static ModelBinder? MakeModelBinder(CommandDescriptor descriptor)
@@ -80,7 +81,7 @@ namespace System.CommandLine.GeneralAppModel
         protected override Option MakeOption(OptionDescriptor descriptor)
         {
             var _ = descriptor.Name ?? throw new InvalidOperationException("The name for an option cannot be null");
-            var option = new Option("--" + descriptor.Name.ToKebabCase(), descriptor.Description);
+            var option = new Option(descriptor.CommandLineName, descriptor.Description);
             if (descriptor.Arguments.Any())
             {
                 option.Argument = descriptor
@@ -102,7 +103,7 @@ namespace System.CommandLine.GeneralAppModel
             {
                 throw new InvalidOperationException("The descriptor cannot be null");
             }
-            var arg = new Argument(descriptor.Name ?? string.Empty)
+            var arg = new Argument(descriptor.CommandLineName ?? string.Empty)
             {
                 ArgumentType = descriptor.ArgumentType.GetArgumentType<Type>() // need work here for Roslyn source generation
             };
@@ -117,7 +118,7 @@ namespace System.CommandLine.GeneralAppModel
             descriptor.SetSymbol(arg);
             return arg;
 
-           static void AddArity(ArgumentDescriptor descriptor, Argument arg)
+            static void AddArity(ArgumentDescriptor descriptor, Argument arg)
             {
                 if (descriptor.Arity != null)
                 {
@@ -129,8 +130,8 @@ namespace System.CommandLine.GeneralAppModel
                 }
                 else
                 {
-                    arg.Arity =  new ArgumentArity(
-                                descriptor.Required ? 1: 0,
+                    arg.Arity = new ArgumentArity(
+                                descriptor.Required ? 1 : 0,
                                 arg.Arity.MaximumNumberOfValues);
                 }
             }

--- a/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ArgumentDescriptor.cs
@@ -5,8 +5,9 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
     public class ArgumentDescriptor : SymbolDescriptor
     {
         public ArgumentDescriptor(ArgTypeInfo argumentTypeInfo, ISymbolDescriptor parentSymbolDescriptorBase,
+                                   string originalName,
                                    object? raw)
-            : base(parentSymbolDescriptorBase, raw, SymbolType.Argument)
+            : base(parentSymbolDescriptorBase, originalName,raw,  SymbolType.Argument)
         {
             ArgumentType = argumentTypeInfo;
         }
@@ -19,7 +20,7 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public DefaultValueDescriptor? DefaultValue { get; set; }
         public bool Required { get; set; }
 
-        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity )
+        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             return $"{whitespace}Arity:{Arity}" +

--- a/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/CommandDescriptor.cs
@@ -9,8 +9,9 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
     public class CommandDescriptor : SymbolDescriptor
     {
         public CommandDescriptor(ISymbolDescriptor parentSymbolDescriptorBase,
+                                 string originalName,
                                  object? raw)
-            : base(parentSymbolDescriptorBase, raw,  SymbolType.Command) { }
+            : base(parentSymbolDescriptorBase, originalName, raw, SymbolType.Command) { }
 
         public bool TreatUnmatchedTokensAsErrors { get; set; } = true;
         public List<ArgumentDescriptor> Arguments { get; } = new List<ArgumentDescriptor>();
@@ -18,7 +19,7 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public InvokeMethodInfo? InvokeMethod { get; set; } // in Reflection models, this is a MethodInfo, in Roslyn it will be something else
         public List<CommandDescriptor> SubCommands { get; } = new List<CommandDescriptor>();
 
-        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity )
+        public override string ReportInternal(int tabsCount, VerbosityLevel verbosity)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
             return $"{whitespace}TreatUnmatchedTokensAsErrors:{TreatUnmatchedTokensAsErrors}" +

--- a/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/ISymbolDescriptor.cs
@@ -11,6 +11,7 @@ namespace System.CommandLine.GeneralAppModel
         string? Description { get; }
         string? Name { get; }
         string? CommandLineName { get; }
+        string OriginalName { get; }
         bool IsHidden { get; set; }
         string Report(int tabsCount, VerbosityLevel verbosity);
     }

--- a/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/OptionDescriptor.cs
@@ -5,8 +5,9 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
     public class OptionDescriptor : SymbolDescriptor
     {
         public OptionDescriptor(ISymbolDescriptor parentSymbolDescriptorBase, 
+                                string originalName,
                                 object? raw)
-            : base(parentSymbolDescriptorBase, raw,  SymbolType.Option) { }
+            : base(parentSymbolDescriptorBase, originalName, raw, SymbolType.Option) { }
 
         public List<ArgumentDescriptor> Arguments { get; } = new List<ArgumentDescriptor>();
         public bool Required { get; set; }
@@ -15,7 +16,7 @@ namespace System.CommandLine.GeneralAppModel.Descriptors
         public override string ReportInternal(int tabsCount, VerbosityLevel verbosity)
         {
             string whitespace = CoreExtensions.NewLineWithTabs(tabsCount);
-            return $"{whitespace}Required:{Required}" ;
+            return $"{whitespace}Required:{Required}";
         }
 
     }

--- a/System.CommandLine.GeneralAppModel/Descriptors/SymbolDescriptor.cs
+++ b/System.CommandLine.GeneralAppModel/Descriptors/SymbolDescriptor.cs
@@ -7,12 +7,21 @@ namespace System.CommandLine.GeneralAppModel
 
     public class EmptySymbolDescriptor : ISymbolDescriptor
     {
+        public EmptySymbolDescriptor()
+        {
+            OriginalName = string.Empty;
+        }
         public SymbolType SymbolType { get; }
         public object? Raw { get; }
         public IEnumerable<string>? Aliases { get; }
         public string? Description { get; }
-        public string? Name { get; }
+
+          public string? Name { get; }
+
         public string? CommandLineName { get; }
+
+        public string OriginalName { get; }
+
         public bool IsHidden { get; set; }
 
         public  string Report(int tabsCount, VerbosityLevel verbosity)
@@ -24,11 +33,13 @@ namespace System.CommandLine.GeneralAppModel
         public static ISymbolDescriptor Empty = new EmptySymbolDescriptor();
 
         public SymbolDescriptor(ISymbolDescriptor parentSymbolDescriptorBase,
+                                    string originalName,
                                     object? raw,
                                     SymbolType symbolType)
         {
             ParentSymbolDescriptorBase = parentSymbolDescriptorBase;
             Raw = raw;
+            OriginalName = originalName;
             SymbolType = symbolType;
         }
 
@@ -92,8 +103,35 @@ namespace System.CommandLine.GeneralAppModel
         public IEnumerable<string>? Aliases { get; set; }
         // TODO: Understand raw aliases: public IReadOnlyList<string> RawAliases { get; }
         public string? Description { get; set; }
+
+        /// <summary>
+        /// The name as used to communicate with the end user. For example, an Arg suffix might be removed
+        /// but the option prefix is not included.
+        /// </summary>
+        /// <remarks>
+        /// The Name should not be ambiguous with an OriginalName and vice versa. For example, if you are 
+        /// removing Arg suffixes via rules (a standard scenario), then having an BlahArg and a BlahArgArg 
+        /// argument woudl not be legal. 
+        /// </remarks>
         public virtual string? Name { get; set; }
-        public string? CommandLineName { get; }
+
+        /// <summary>
+        /// The name as used when System.CommandLine objects are created. This name includes option prefixes
+        /// and is the name as it should appear in automated help. 
+        /// </summary>
+        public string? CommandLineName { get; set; }
+
+        /// <summary>
+        /// The original name in the model. This is used for DescriptionSource (which recognizes either Name or 
+        /// OriginalName
+        /// </summary>
+        /// <remarks>
+        /// The Name should not be ambiguous with an OriginalName and vice versa. For example, if you are 
+        /// removing Arg suffixes via rules (a standard scenario), then having an BlahArg and a BlahArgArg 
+        /// argument woudl not be legal. 
+        /// </remarks>
+        public string OriginalName { get; }
+
         public bool IsHidden { get; set; }
     }
 }

--- a/System.CommandLine.GeneralAppModel/FullRules.cs
+++ b/System.CommandLine.GeneralAppModel/FullRules.cs
@@ -44,6 +44,9 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new IdentityRule<string>())
                 ;
 
+            //rules.CommandLineNameRules  // None for now
+            //;
+
             rules.DefaultValueRules
                 .Add(new AttributeWithOptionalValueRule<DefaultValueAttribute, object>( ))
                 // DefaultValue on the Argument attribute is not trivial becaues we need to recognize when that is set in a generalized way"
@@ -89,6 +92,11 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new AttributeWithPropertyValueRule<OptionAttribute, string>( "Name"))
                 .Add(new NameEndsWithRule("Option"))
                 .Add(new IdentityRule<string>());
+
+            rules.CommandLineNameRules
+                .Add(new MorphNameCasingRule(MorphNameCasingRule.StringCasing.LowerKebab))
+                .Add(new MorphNamePrefixRule("--"))
+            ;
 
             rules.RequiredRules
                 .Add(new BooleanAttributeRule<RequiredAttribute>())
@@ -153,6 +161,10 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new AttributeWithPropertyValueRule<CommandAttribute, string>( "Name"))
                 .Add(new NameEndsWithRule("Command"))
                 .Add(new IdentityRule<string>())
+            ;
+
+            rules.CommandLineNameRules
+                .Add(new MorphNameCasingRule(MorphNameCasingRule.StringCasing.LowerKebab))
             ;
 
             rules.TreatUnmatchedTokensAsErrorsRules

--- a/System.CommandLine.GeneralAppModel/IdentityWrapper.cs
+++ b/System.CommandLine.GeneralAppModel/IdentityWrapper.cs
@@ -5,8 +5,10 @@
     /// supporting StringContentRules and supports non-string identity types. "Identity" here is the sense 
     /// of "Just use this value" not the sense of "This value is the name", although it often is the name.
     /// </summary>
-    public class IdentityWrapper
-    { }
+    public abstract class IdentityWrapper
+    {
+        public abstract object? ValueAsObject { get; }
+    }
 
     public class IdentityWrapper<T> : IdentityWrapper
     {
@@ -15,5 +17,7 @@
             Value = value;
         }
         public T Value { get; }
+        public override object? ValueAsObject
+            => Value;
     }
 }

--- a/System.CommandLine.GeneralAppModel/RuleGroup.cs
+++ b/System.CommandLine.GeneralAppModel/RuleGroup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 
 namespace System.CommandLine.GeneralAppModel
 {
@@ -81,6 +82,20 @@ namespace System.CommandLine.GeneralAppModel
             }
             return values;
         }
+
+        public virtual string MorphNameAgainstAllRules(string name, 
+                                                       ISymbolDescriptor symbolDescriptor,
+                                                       Candidate candidate,
+                                                       ISymbolDescriptor parentSymbolDescriptor)
+        {
+            var nameRules = Rules.OfType<IMorphNameRule >().ToList();
+            foreach (var rule in nameRules)
+            {
+                name = rule.MorphName(name, symbolDescriptor, candidate.Traits, parentSymbolDescriptor);
+            }
+            return name;
+        }
+
         public void ReplaceAbstractRules(DescriptorMakerSpecificSourceBase tools)
         {
             var abstractRules = this.Where(r => typeof(IAbstractRule).IsAssignableFrom(r.GetType()));
@@ -134,5 +149,6 @@ namespace System.CommandLine.GeneralAppModel
                 return derivedType;
             }
         }
+    
     }
 }

--- a/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSymbol.cs
+++ b/System.CommandLine.GeneralAppModel/RuleSet/RuleSetSymbol.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.CommandLine.GeneralAppModel.Rules;
 using System.Linq;
 
 namespace System.CommandLine.GeneralAppModel
@@ -12,6 +13,7 @@ namespace System.CommandLine.GeneralAppModel
         /// Some NameRules will also morph the names. When morphing names, only those name rules with IRuleMorphValue<string>  will be used
         /// </summary>
         public RuleGroup<IRuleGetValue<string>> NameRules { get; } = new RuleGroup<IRuleGetValue<string>>();
+        public RuleGroup<IMorphNameRule> CommandLineNameRules { get; } = new RuleGroup<IMorphNameRule>();
         public RuleGroup<IRuleGetValues<string[]>> AliasRules { get; } = new RuleGroup<IRuleGetValues<string[]>>();
         public RuleGroup<IRuleGetValue<bool>> IsHiddenRules { get; } = new RuleGroup<IRuleGetValue<bool>>();
 
@@ -31,7 +33,7 @@ namespace System.CommandLine.GeneralAppModel
                     + IsHiddenRules.ReportRuleGroup(tabsCount, "whether to hide this in the CLI");
         }
 
-        public  virtual IEnumerable<DetailReportStructure> GetRulesReportStructure()
+        public virtual IEnumerable<DetailReportStructure> GetRulesReportStructure()
         {
             return NameRules.Select(x => new DetailReportStructure("Name", x.RuleDescription<RuleSetSymbol>(), x.GetType()))
                 .Union(DescriptionRules.Select(x => new DetailReportStructure("Description", x.RuleDescription<RuleSetSymbol>(), x.GetType())))

--- a/System.CommandLine.GeneralAppModel/Rules/AttributeRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/AttributeRule.cs
@@ -26,8 +26,6 @@ namespace System.CommandLine.GeneralAppModel
                  trait => DescriptorMakerSpecificSourceBase.Tools.DoesTraitMatch<TAttribute, TTraitType>(symbolDescriptor, trait, parentSymbolDescriptor));
 
         public override string RuleDescription<TIRuleSet>()
-           => (typeof(IRuleGetValue<string>).IsAssignableFrom(typeof(TIRuleSet))
-                ? "If " : "")
-            + $"with an attribute named '{typeof(TAttribute).Name.WithoutAttributeSuffix()}'";
+           =>  $"with an attribute named '{typeof(TAttribute).Name.WithoutAttributeSuffix()}'";
     }
 }

--- a/System.CommandLine.GeneralAppModel/Rules/IRuleMorphString.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/IRuleMorphString.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public interface IMorphNameRule : IRule
+    {
+        string MorphName(string name,
+                         ISymbolDescriptor symbolDescriptor,
+                         IEnumerable<object> traits,
+                         ISymbolDescriptor parentSymbolDescriptor);
+    }
+}

--- a/System.CommandLine.GeneralAppModel/Rules/MorphNameCasingRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/MorphNameCasingRule.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.CommandLine.Parsing;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public class MorphNameCasingRule : RuleBase, IMorphNameRule
+    {
+        public MorphNameCasingRule(StringCasing stringCasing, SymbolType symbolType = SymbolType.All) : base(symbolType)
+        {
+            Casing = stringCasing;
+        }
+
+        public StringCasing Casing { get; }
+
+        public string MorphName(string name, ISymbolDescriptor symbolDescriptor, IEnumerable<object> traits, ISymbolDescriptor parentSymbolDescriptor)
+        {
+            if (name is null)
+            {
+                return name;
+            }
+            // Order of operations matter below. Kebab and anything else acting on caps must be first
+            name = Casing.HasFlag(StringCasing.Kebab)
+                    ? name.ToKebabCase()
+                    : name;
+            name = Casing.HasFlag(StringCasing.Lower)
+                    ? name.ToLower()
+                    : name;
+            name = Casing.HasFlag(StringCasing.Upper)
+                    ? name.ToUpper()
+                    : name;
+
+            return name;
+        }
+
+        public override string RuleDescription<TIRuleSet>()
+            => $"change to {Casing} casing";
+
+        [Flags]
+        public enum StringCasing
+        {
+            None = 0,
+            Lower = 0b0001,
+            Upper = 0b0010,
+            Kebab = 0b0100,
+
+            LowerKebab = 0b0101
+        }
+    }
+}

--- a/System.CommandLine.GeneralAppModel/Rules/MorphNamePrefixRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/MorphNamePrefixRule.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public class MorphNamePrefixRule : RuleBase, IMorphNameRule
+    {
+        public MorphNamePrefixRule(string stringToAdd,  SymbolType symbolType = SymbolType.All) : base(symbolType)
+        {
+            StringToAdd = stringToAdd;
+        }
+
+        public string StringToAdd { get; }
+
+        public string MorphName(string name, ISymbolDescriptor symbolDescriptor, IEnumerable<object> traits, ISymbolDescriptor parentSymbolDescriptor) 
+            => StringToAdd + name;
+
+        public override string RuleDescription<TIRuleSet>() 
+            => $"add the {StringToAdd} prefix";
+    }
+}

--- a/System.CommandLine.GeneralAppModel/Rules/MorphNameSuffixRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/MorphNameSuffixRule.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace System.CommandLine.GeneralAppModel
+{
+    public class MorphNameSuffixRule : RuleBase, IMorphNameRule
+    {
+        public MorphNameSuffixRule(string stringToAdd, SymbolType symbolType = SymbolType.All) : base(symbolType)
+        {
+            StringToAdd = stringToAdd;
+        }
+
+        public string StringToAdd { get; }
+
+        public string MorphName(string name, ISymbolDescriptor symbolDescriptor, IEnumerable<object> traits, ISymbolDescriptor parentSymbolDescriptor)
+            => name + StringToAdd;
+
+        public override string RuleDescription<TIRuleSet>()
+            => $"add the {StringToAdd} suffix";
+    }
+}

--- a/System.CommandLine.GeneralAppModel/Rules/StringContentsRule.cs
+++ b/System.CommandLine.GeneralAppModel/Rules/StringContentsRule.cs
@@ -17,12 +17,7 @@ namespace System.CommandLine.GeneralAppModel
         public StringPosition Position { get; }
         public string CompareTo { get; }
 
-        public enum StringPosition
-        {
-            BeginsWith = 1,
-            EndsWith,
-            Contains
-        }
+ 
 
         protected virtual string MorphValueInternal(ISymbolDescriptor symbolDescriptor,
                                                     object item,

--- a/System.CommandLine.GeneralAppModel/StandardRules.cs
+++ b/System.CommandLine.GeneralAppModel/StandardRules.cs
@@ -48,6 +48,9 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new IdentityRule<string>())
                 ;
 
+            //rules.CommandLineNameRules  // None for now
+            //;
+
             rules.RequiredRules
                 .Add(new BooleanAttributeRule<ArgumentAttribute>("Required"))
             ;
@@ -89,6 +92,11 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new NameEndsWithRule("Option"))
                 .Add(new IdentityRule<string>());
 
+            rules.CommandLineNameRules
+                .Add(new MorphNameCasingRule(MorphNameCasingRule.StringCasing.LowerKebab))
+                .Add(new MorphNamePrefixRule("--")) 
+            ;
+
             rules.RequiredRules
                 .Add(new BooleanAttributeRule<OptionAttribute>("OptionRequired"))
              ;
@@ -120,7 +128,7 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new AttributeWithPropertyValueRule<OptionAttribute, bool>("ArgumentRequired", SymbolType.Option))
             ;
 
-            rules.RequiredRules
+            rules.IsHiddenRules
                 .Add(new AttributeWithPropertyValueRule<OptionAttribute, bool>("ArgumentIsHidden", SymbolType.Option))
             ;
 
@@ -147,6 +155,10 @@ namespace System.CommandLine.GeneralAppModel
                 .Add(new AttributeWithPropertyValueRule<CommandAttribute, string>("Name"))
                 .Add(new NameEndsWithRule("Command"))
                 .Add(new IdentityRule<string>())
+            ;
+
+            rules.CommandLineNameRules
+                .Add(new MorphNameCasingRule(MorphNameCasingRule.StringCasing.LowerKebab))
             ;
 
             rules.TreatUnmatchedTokensAsErrorsRules

--- a/System.CommandLine.GeneralAppModel/StringPosition.cs
+++ b/System.CommandLine.GeneralAppModel/StringPosition.cs
@@ -1,0 +1,9 @@
+﻿namespace System.CommandLine.GeneralAppModel
+{
+    public enum StringPosition
+    {
+        BeginsWith = 1,
+        EndsWith,
+        Contains
+    }
+}


### PR DESCRIPTION
Updated names to triumverate fixing argument desc and added name morphing rules.

Names are now:

* OriginalName: Generally name as appears in source
* Name: The name it would be known by generally
* CommandLineName: The name as used for System.CommandLine - passed through morphing rules

Added morphing rules, they now appear in Full and Standard Rules. 

Fixed #101 